### PR TITLE
remove duplicate param definitions

### DIFF
--- a/metadata_service/config.py
+++ b/metadata_service/config.py
@@ -23,9 +23,6 @@ class Config(ApiConfigBase):
 
     # config parameter needed for the api server
     # are inherited from ApiConfigBase
-    host: str = "127.0.0.1"
-    port: int = 8000
-    log_level: str = "info"
     db_url: str = "mongodb://localhost:27017"
     db_name: str = "metadata"
 


### PR DESCRIPTION
The removed params are already specified in the ghga_service_chassis_lib: https://github.com/ghga-de/ghga-service-chassis-lib/blob/main/ghga_service_chassis_lib/api.py#L34-L38