### PR TITLE
Fix get all routes

### DIFF
--- a/metadata_service/dao/data_access_committee.py
+++ b/metadata_service/dao/data_access_committee.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Convenience methods for adding, updating, and retrieving Data Access Committee objects"""
+
 from typing import List, Dict
 from fastapi.exceptions import HTTPException
 
@@ -23,15 +25,15 @@ from metadata_service.models import DataAccessCommittee
 COLLECTION_NAME = DataAccessCommittee.__collection__
 
 
-async def retrieve_dacs() -> List[str]:
+async def retrieve_dacs() -> List[Dict]:
     """Retrieve a list of DACs from metadata store.
 
     Returns:
-      A list of DAC IDs.
+      A list of DAC objects.
 
     """
     collection = await get_collection(COLLECTION_NAME)
-    dacs = await collection.distinct("id")
+    dacs = await collection.find().to_list(None)
     return dacs
 
 

--- a/metadata_service/dao/data_access_policy.py
+++ b/metadata_service/dao/data_access_policy.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Convenience methods for adding, updating, and retrieving Data Access Policy objects"""
 
 from typing import List, Dict
 from fastapi.exceptions import HTTPException
@@ -23,15 +24,15 @@ from metadata_service.models import DataAccessPolicy
 COLLECTION_NAME = DataAccessPolicy.__collection__
 
 
-async def retrieve_daps() -> List[str]:
+async def retrieve_daps() -> List[Dict]:
     """Retrieve a list of DAPs from metadata store.
 
     Returns:
-      A list of DAP IDs.
+      A list of DAP objects.
 
     """
     collection = await get_collection(COLLECTION_NAME)
-    daps = await collection.distinct("id")
+    daps = await collection.find().to_list(None)
     return daps
 
 

--- a/metadata_service/dao/dataset.py
+++ b/metadata_service/dao/dataset.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Convenience methods for adding, updating, and retrieving Dataset objects"""
+
 from typing import List, Dict
 from fastapi.exceptions import HTTPException
 
@@ -23,15 +25,15 @@ from metadata_service.models import Dataset
 COLLECTION_NAME = Dataset.__collection__
 
 
-async def retrieve_datasets() -> List[str]:
+async def retrieve_datasets() -> List[Dict]:
     """Retrieve a list of Datasets from metadata store.
 
     Returns:
-      A list of Dataset IDs.
+      A list of Dataset objects.
 
     """
     collection = await get_collection(COLLECTION_NAME)
-    datasets = await collection.distinct("id")
+    datasets = await collection.find().to_list(None)
     return datasets
 
 

--- a/metadata_service/dao/experiment.py
+++ b/metadata_service/dao/experiment.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Convenience methods for adding, updating, and retrieving Experiment objects"""
 
 from typing import List, Dict
 from fastapi.exceptions import HTTPException
@@ -23,15 +24,15 @@ from metadata_service.models import Experiment
 COLLECTION_NAME = Experiment.__collection__
 
 
-async def retrieve_experiments() -> List[str]:
+async def retrieve_experiments() -> List[Dict]:
     """Retrieve a list of Experiments from metadata store.
 
     Returns:
-      A list of Experiment IDs.
+      A list of Experiment objects.
 
     """
     collection = await get_collection(COLLECTION_NAME)
-    experiments = await collection.distinct("id")
+    experiments = await collection.find().to_list(None)
     return experiments
 
 

--- a/metadata_service/dao/file.py
+++ b/metadata_service/dao/file.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Convenience methods for adding, updating, and retrieving File objects"""
 
 from typing import List, Dict
 from fastapi.exceptions import HTTPException
@@ -23,15 +24,15 @@ from metadata_service.models import File
 COLLECTION_NAME = File.__collection__
 
 
-async def retrieve_files() -> List[str]:
+async def retrieve_files() -> List[Dict]:
     """Retrieve a list of File IDs from metadata store.
 
     Returns:
-      A list of File IDs.
+      A list of File objects.
 
     """
     collection = await get_collection(COLLECTION_NAME)
-    files = await collection.distinct("id")
+    files = await collection.find().to_list(None)
     return files
 
 

--- a/metadata_service/dao/publication.py
+++ b/metadata_service/dao/publication.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Convenience methods for adding, updating, and retrieving Publication objects"""
 
 from typing import List, Dict
 from fastapi.exceptions import HTTPException
@@ -23,15 +24,15 @@ from metadata_service.models import Publication
 COLLECTION_NAME = Publication.__collection__
 
 
-async def retrieve_publications() -> List[str]:
+async def retrieve_publications() -> List[Dict]:
     """Retrieve a list of Publications from metadata store.
 
     Returns:
-      A list of Publication IDs.
+      A list of Publication objects.
 
     """
     collection = await get_collection(COLLECTION_NAME)
-    publications = await collection.distinct("id")
+    publications = await collection.find().to_list(None)
     return publications
 
 

--- a/metadata_service/dao/study.py
+++ b/metadata_service/dao/study.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Convenience methods for adding, updating, and retrieving Study objects"""
+
 from typing import List, Dict
 from fastapi.exceptions import HTTPException
 
@@ -23,15 +25,15 @@ from metadata_service.models import Study
 COLLECTION_NAME = Study.__collection__
 
 
-async def retrieve_studies() -> List[str]:
+async def retrieve_studies() -> List[Dict]:
     """Retrieve a list of Studies from metadata store.
 
     Returns:
-      A list of Study IDs.
+      A list of Study objects.
 
     """
     collection = await get_collection(COLLECTION_NAME)
-    studies = await collection.distinct("id")
+    studies = await collection.find().to_list(None)
     return studies
 
 

--- a/metadata_service/routes/data_access_committee.py
+++ b/metadata_service/routes/data_access_committee.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Routes for Data Access Committee objects"""
+
 from typing import List, Dict
 from fastapi import APIRouter
 
@@ -29,7 +31,9 @@ data_access_committee_router = APIRouter()
 
 
 @data_access_committee_router.get(
-    "/data_access_committees", response_model=List[str], summary="Get all DAC IDs"
+    "/data_access_committees",
+    response_model=List[DataAccessCommittee],
+    summary="Get all DACs",
 )
 async def get_all_dacs():
     """Retrieve a list of DAC IDs from metadata store."""

--- a/metadata_service/routes/data_access_policy.py
+++ b/metadata_service/routes/data_access_policy.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Routes for Data Access Policy objects"""
 
 from typing import List, Dict
 from fastapi import APIRouter
@@ -29,7 +30,9 @@ data_access_policy_router = APIRouter()
 
 
 @data_access_policy_router.get(
-    "/data_access_policies", response_model=List[str], summary="Get all DAP IDs"
+    "/data_access_policies",
+    response_model=List[DataAccessPolicy],
+    summary="Get all DAPs",
 )
 async def get_all_daps():
     """Retrieve a list of DAP IDs from metadata store."""

--- a/metadata_service/routes/datasets.py
+++ b/metadata_service/routes/datasets.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Routes for Dataset objects"""
 
 from typing import List, Dict
 from fastapi import APIRouter
@@ -29,7 +30,7 @@ dataset_router = APIRouter()
 
 
 @dataset_router.get(
-    "/datasets", response_model=List[str], summary="Get all Dataset IDs"
+    "/datasets", response_model=List[Dataset], summary="Get all Datasets"
 )
 async def get_all_datasets():
     """Retrieve a list of Dataset IDs from metadata store."""

--- a/metadata_service/routes/experiments.py
+++ b/metadata_service/routes/experiments.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Routes for Experiment objects"""
 
 from typing import List, Dict
 from fastapi import APIRouter
@@ -29,7 +30,7 @@ experiment_router = APIRouter()
 
 
 @experiment_router.get(
-    "/experiments", response_model=List[str], summary="Get all Experiment IDs"
+    "/experiments", response_model=List[Experiment], summary="Get all Experiments"
 )
 async def get_all_experiments():
     """Retrieve a list of Experiment IDs from metadata store."""

--- a/metadata_service/routes/files.py
+++ b/metadata_service/routes/files.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Routes for File objects"""
 
 from typing import List, Dict
 from fastapi import APIRouter
@@ -23,7 +24,7 @@ from metadata_service.models import File
 file_router = APIRouter()
 
 
-@file_router.get("/files", response_model=List[str], summary="Get all File IDs")
+@file_router.get("/files", response_model=List[File], summary="Get all Files")
 async def get_all_files():
     """Retrieve a list of File IDs from metadata store."""
     files = await retrieve_files()

--- a/metadata_service/routes/health.py
+++ b/metadata_service/routes/health.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Health endpoint"""
 
 from fastapi import APIRouter
@@ -21,6 +20,6 @@ health_router = APIRouter()
 
 
 @health_router.get("/health", summary="Check health of service")
-async def get_all_datasets():
+async def get_health():
     """Check health of service."""
     return {"status": "OK"}

--- a/metadata_service/routes/publications.py
+++ b/metadata_service/routes/publications.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Routes for Publication objects"""
+
 from typing import List, Dict
 from fastapi import APIRouter
 
@@ -29,7 +31,7 @@ publication_router = APIRouter()
 
 
 @publication_router.get(
-    "/publications", response_model=List[str], summary="Get all Publication IDs"
+    "/publications", response_model=List[Publication], summary="Get all Publications"
 )
 async def get_all_publications():
     """Retrieve a list of Publication IDs from metadata store."""

--- a/metadata_service/routes/studies.py
+++ b/metadata_service/routes/studies.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Routes for Study objects"""
+
 from typing import List, Dict
 from fastapi import APIRouter
 
@@ -28,7 +30,7 @@ from metadata_service.models import Study
 studies_router = APIRouter()
 
 
-@studies_router.get("/studies", response_model=List[str], summary="Get all Study IDs")
+@studies_router.get("/studies", response_model=List[Study], summary="Get all Studies")
 async def get_all_studies():
     """Retrieve a list of Study IDs from metadata store."""
     studies = await retrieve_studies()

--- a/tests/integration/test_dataset_routes.py
+++ b/tests/integration/test_dataset_routes.py
@@ -6,13 +6,13 @@ def test_get_dataset_route(initialize_test_db, api_client):
     """Test fetching dataset records from metadata store"""
     response = api_client.get('/datasets')
     assert response.status_code == 200
-    dataset_list = response.json()
+    dataset_list = [x['id'] for x in response.json()]
     assert isinstance(dataset_list, list)
     assert 'DAT:0000001' in dataset_list
     assert 'DAT:0000002' in dataset_list
 
-    for dataset_id in dataset_list:
-        response = api_client.get(f'/datasets/{dataset_id}')
+    for d in dataset_list:
+        response = api_client.get(f"/datasets/{d['id']}")
         assert response.status_code == 200
         dataset = response.json()
         assert dataset['id'] in dataset_list

--- a/tests/integration/test_experiment_routes.py
+++ b/tests/integration/test_experiment_routes.py
@@ -6,13 +6,13 @@ def test_get_experiment_route(initialize_test_db, api_client):
     """Test fetching experiment records from metadata store"""
     response = api_client.get('/experiments')
     assert response.status_code == 200
-    experiment_list = response.json()
+    experiment_list = [x['id'] for x in response.json()]
     assert isinstance(experiment_list, list)
     assert 'EXP:0000001' in experiment_list
     assert 'EXP:0000002' in experiment_list
 
-    for exp_id in experiment_list:
-        response = api_client.get(f'/experiments/{exp_id}')
+    for e in experiment_list:
+        response = api_client.get(f"/experiments/{e['id']}")
         assert response.status_code == 200
         experiment = response.json()
         assert experiment['id'] in experiment_list

--- a/tests/integration/test_study_routes.py
+++ b/tests/integration/test_study_routes.py
@@ -6,13 +6,13 @@ def test_get_study_route(initialize_test_db, api_client):
     """Test fetching study records from metadata store"""
     response = api_client.get('/studies')
     assert response.status_code == 200
-    study_list = response.json()
+    study_list = [x['id'] for x in response.json()]
     assert isinstance(study_list, list)
     assert 'STU:0000001' in study_list
     assert 'STU:0000002' in study_list
 
-    for study_id in study_list:
-        response = api_client.get(f'/studies/{study_id}')
+    for s in study_list:
+        response = api_client.get(f"/studies/{s['id']}")
         assert response.status_code == 200
         study = response.json()
         assert study['id'] in study_list


### PR DESCRIPTION
This PR fixes get_all* routes for each object type such that the response is a list of objects instead of list of IDs (as seen previously).