### PR TITLE
GDEV-161: Adapt EGA metadata from GHGA website for the sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,22 +19,6 @@ docker build -t sandbox-metadata:dev -f .devcontainer/Dockerfile .
 docker run --rm -it -u vscode -v "${PWD}:/workspace" sandbox-metadata:dev bash
 ```
 
-## Bootstrapping the metadata store
-
-The metadata-store is a MongoDB instance that holds GHGA metadata records.
-
-Each type of metadata record (Dataset, Study, etc.) is stored as a separate collection in the metadata-store.
-
-To pre-load metadata records into a fresh instance of MongoDB:
-
-```sh
-# load GHGA metadata records
-python scripts/populate_metadata_store.py --base-url http://localhost:8000 --directory examples
-
-# load GHGA metadata records translated from EGA
-python scripts/populate_metadata_store.py --base-url http://localhost:8000 --directory ega-examples/transformed
-```
-
 
 ## Running the application
 
@@ -51,3 +35,20 @@ uvicorn metadata_service.main:app --reload
 ```
 
 You can visit the API by navigating to [http://localhost:8000/docs]()
+
+
+## Bootstrapping the metadata store
+
+The metadata-store is a MongoDB instance that holds GHGA metadata records.
+
+Each type of metadata record (Dataset, Study, etc.) is stored as a separate collection in the metadata-store.
+
+To pre-load metadata records into a fresh instance of MongoDB:
+
+```sh
+# load GHGA metadata records
+python scripts/populate_metadata_store.py --base-url http://localhost:8000 --directory examples
+
+# load GHGA metadata records translated from EGA
+python scripts/populate_metadata_store.py --base-url http://localhost:8000 --directory ega-examples/transformed
+```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ docker build -t sandbox-metadata:dev -f .devcontainer/Dockerfile .
 docker run --rm -it -u vscode -v "${PWD}:/workspace" sandbox-metadata:dev bash
 ```
 
+## Bootstrapping the metadata store
+
+The metadata-store is a MongoDB instance that holds GHGA metadata records.
+
+Each type of metadata record (Dataset, Study, etc.) is stored as a separate collection in the metadata-store.
+
+To pre-load metadata records into a fresh instance of MongoDB:
+
+```sh
+# load GHGA metadata records
+python scripts/populate_metadata_store.py --base-url http://localhost:8000 --directory examples
+
+# load GHGA metadata records translated from EGA
+python scripts/populate_metadata_store.py --base-url http://localhost:8000 --directory ega-examples/transformed
+```
+
 
 ## Running the application
 

--- a/ega-examples/original/README.md
+++ b/ega-examples/original/README.md
@@ -1,0 +1,3 @@
+# EGA metadata JSON Examples
+
+This folder consists of EGA metadata in JSON from https://github.com/ghga-de/online/tree/master/assets/data

--- a/ega-examples/original/dacs.json
+++ b/ega-examples/original/dacs.json
@@ -1,0 +1,331 @@
+[
+  {
+    "alias": "ena-DAC-NEUROMICS-06-02-2014-23:56:38:036-41",
+    "centerName": "Neuromics",
+    "contacts": [
+      {
+        "contactName": "Birte Zurek",
+        "email": "birte.zurek@med.uni-tuebingen.de",
+        "mainContact": false,
+        "organisation": "University of Tuebingen Institute of Medical Genetics and Applied Genomics",
+        "phoneNumber": "+4970712972285"
+      }
+    ],
+    "creationTime": "2014-02-06T22:21.000Z",
+    "egaStableId": "EGAC00001000165",
+    "published": true,
+    "released": "RELEASED",
+    "title": "Neuromics Data Access Committee",
+    "url": "NA"
+  },
+  {
+    "alias": "ena-DAC-DKFZ-IBIOS-30-07-2014-08:33:05:360-399",
+    "centerName": "DKFZ-IBIOS",
+    "contacts": [
+      {
+        "contactName": "DKTK DAC",
+        "email": "daco-dkfz-b06x@dkfz-heidelberg.de",
+        "mainContact": true,
+        "organisation": "German Cancer Research Center (DKFZ)",
+        "phoneNumber": null
+      }
+    ],
+    "creationTime": "2014-07-30T06:16.000Z",
+    "egaStableId": "EGAC00001000217",
+    "published": true,
+    "released": "RELEASED",
+    "title": "Data Access Committee for German Consortium for Translational Cancer Research (DKTK)",
+    "url": "not provided"
+  },
+  {
+    "alias": "ena-DAC-DKFZ-IBIOS-31-07-2014-15:32:43:877-13",
+    "centerName": "DKFZ-IBIOS",
+    "contacts": [
+      {
+        "contactName": "DACO B060x",
+        "email": "daco-dkfz-b06x@dkfz-heidelberg.de",
+        "mainContact": true,
+        "organisation": "German Cancer Research Center (DKFZ)",
+        "phoneNumber": null
+      }
+    ],
+    "creationTime": "2014-07-31T13:54.000Z",
+    "egaStableId": "EGAC00001000219",
+    "published": true,
+    "released": "RELEASED",
+    "title": "Data Access Committee of divisions B060 and B062, German Cancer Research Center (DKFZ)",
+    "url": "not provided"
+  },
+  {
+    "alias": "ena-DAC-TUSCO-27-02-2015-13:57:59:212-261",
+    "centerName": "TUSCO",
+    "contacts": [
+      {
+        "contactName": "Matthias Schwab",
+        "email": "matthias.schwab@ikp-stuttgart.de",
+        "mainContact": true,
+        "organisation": "Dr Margarete Fischer-Bosch-Institute of Clinical Pharmacology, Stuttgart, Germany",
+        "phoneNumber": null
+      },
+      {
+        "contactName": "Elke Schäffeler",
+        "email": "elke.schaeffeler@ikp-stuttgart.de",
+        "mainContact": false,
+        "organisation": "Dr Margarete Fischer-Bosch-Institute of Clinical Pharmacology, Stuttgart, Germany",
+        "phoneNumber": null
+      },
+      {
+        "contactName": "Jens Bedke",
+        "email": "jens.bedke@med.uni-tuebingen.de",
+        "mainContact": false,
+        "organisation": "Department of Urology, University Hospital Tuebingen, Tuebingen, Germany",
+        "phoneNumber": null
+      },
+      {
+        "contactName": "Florian Büttner",
+        "email": "florian.buettner@ikp-stuttgart.de",
+        "mainContact": false,
+        "organisation": "Dr Margarete Fischer-Bosch-Institute of Clinical Pharmacology, Stuttgart, Germany",
+        "phoneNumber": null
+      },
+      {
+        "contactName": "Stefan Winter",
+        "email": "stefan.winter@ikp-stuttgart.de",
+        "mainContact": false,
+        "organisation": "Dr Margarete Fischer-Bosch-Institute of Clinical Pharmacology, Stuttgart, Germany",
+        "phoneNumber": null
+      },
+      {
+        "contactName": "Arnulf Stenzl",
+        "email": "arnulf.stenzl@med.uni-tuebingen.de",
+        "mainContact": false,
+        "organisation": "Department of Urology, University Hospital Tuebingen, Tuebingen, Germany",
+        "phoneNumber": null
+      }
+    ],
+    "creationTime": "2015-02-27T12:20.000Z",
+    "egaStableId": "EGAC00001000317",
+    "published": true,
+    "released": "RELEASED",
+    "title": "DAC for Tuebingen-Stuttgart cohort",
+    "url": "http://www.ikp-stuttgart.de/content/language1/html/15179.asp"
+  },
+  {
+    "alias": "ena-DAC-DKFZ-IBIOS-01-06-2015-11:13:45:832-184",
+    "centerName": "DKFZ-IBIOS",
+    "contacts": [
+      {
+        "contactName": "Dr. Matthias Schlesner",
+        "email": "m.schlesner@dkfz-heidelberg.de",
+        "mainContact": true,
+        "organisation": "German Cancer Research Center (DKFZ)",
+        "phoneNumber": null
+      }
+    ],
+    "creationTime": "2015-06-01T09:58.000Z",
+    "egaStableId": "EGAC00001000346",
+    "published": true,
+    "released": "RELEASED",
+    "title": "Bioinformatics of Data Analysis (B240)",
+    "url": "not provided"
+  },
+  {
+    "alias": "ena-DAC-DKFZ-IBIOS-28-08-2015-10:49:04:108-238",
+    "centerName": "DKFZ-IBIOS",
+    "contacts": [
+      {
+        "contactName": "Omics &amp; Datamanagment Core Facility",
+        "email": "odcf-service@dkfz-heidelberg.de",
+        "mainContact": true,
+        "organisation": "German Cancer Research Center (DKFZ)",
+        "phoneNumber": null
+      }
+    ],
+    "creationTime": "2015-08-28T08:15.000Z",
+    "egaStableId": "EGAC00001000381",
+    "published": true,
+    "released": "RELEASED",
+    "title": "MMML associated cell line data",
+    "url": "not provided"
+  },
+  {
+    "alias": "ena-DAC-DKFZ-HIPO-17-03-2016-10:18:52:050-451",
+    "centerName": "DKFZ-HIPO",
+    "contacts": [
+      {
+        "contactName": "Katja Beck",
+        "email": "hipo_daco@dkfz-heidelberg.de",
+        "mainContact": false,
+        "organisation": "German Cancer Research Center (DKFZ)",
+        "phoneNumber": null
+      }
+    ],
+    "creationTime": "2016-03-17T09:54.000Z",
+    "egaStableId": "EGAC00001000452",
+    "published": true,
+    "released": "RELEASED",
+    "title": "DKFZ-HIPO Data Access Committee of Heidelberg Center for Personalized Oncology",
+    "url": "not provided"
+  },
+  {
+    "alias": "ena-DAC-MUO-19-04-2016-11:21:22:457-63",
+    "centerName": "MUO",
+    "contacts": [
+      {
+        "contactName": "Stefan Duensing",
+        "email": "stefan.duensing@med.uni-heidelberg.de",
+        "mainContact": true,
+        "organisation": "University of Heidelberg",
+        "phoneNumber": "+496221566255"
+      }
+    ],
+    "creationTime": "2016-04-19T09:24.000Z",
+    "egaStableId": "EGAC00001000470",
+    "published": true,
+    "released": "RELEASED",
+    "title": "University of Heidelberg_MUO",
+    "url": "not provided"
+  },
+  {
+    "alias": "68a8c5d2-7f64-4d4c-974b-365370badf61",
+    "centerName": "CRG",
+    "contacts": [
+      {
+        "contactName": "Stephan Ossowski",
+        "email": "stephan.ossowski@med.uni-tuebingen.de",
+        "mainContact": true,
+        "organisation": "Institute of Medical Genetics and Applied Genomics - Universität Klinikum Tübingen ",
+        "phoneNumber": "070712972323"
+      }
+    ],
+    "creationTime": "2018-05-25T12:31.000Z",
+    "egaStableId": "EGAC00001000916",
+    "published": true,
+    "released": "RELEASED",
+    "title": "ABB DAC",
+    "url": "NA"
+  },
+  {
+    "alias": "4000883f-cae0-4390-941f-bd84577b4af2",
+    "centerName": "EGAB00000001489",
+    "contacts": [
+      {
+        "contactName": "Boutros, Prof. Dr. Michael",
+        "email": "m.boutros@dkfz-heidelberg.de",
+        "mainContact": false,
+        "organisation": "Deutsches Krebsforschungszentrum DKFZ",
+        "phoneNumber": "00496221421951"
+      },
+      {
+        "contactName": "Ebert, Prof. Dr. Matthias",
+        "email": "matthias.ebert@medma.uni-heidelberg.de",
+        "mainContact": false,
+        "organisation": "Universitätsmedizin Mannheim",
+        "phoneNumber": "00496213833284"
+      },
+      {
+        "contactName": "Betge, Dr. Johannes",
+        "email": "j.betge@dkfz-heidelberg.de",
+        "mainContact": true,
+        "organisation": "Deutsches Krebsforschungszentrum DKFZ",
+        "phoneNumber": "00496221421957"
+      }
+    ],
+    "creationTime": "2018-08-27T10:03.000Z",
+    "egaStableId": "EGAC00001000998",
+    "published": true,
+    "released": "RELEASED",
+    "title": "Colorectal Cancer Organoids Data Access Committee",
+    "url": "not provided"
+  },
+  {
+    "alias": "07d65c87-c5ac-4321-a66c-1544bf6e9c0f",
+    "centerName": "EGAB00000001518",
+    "contacts": [
+      {
+        "contactName": "Paulina Richter-Pechanska",
+        "email": "paulina.richter-pechanska@med.uni-heidelberg.de",
+        "mainContact": true,
+        "organisation": "University Hospital in Heidelberg, Germany",
+        "phoneNumber": "+496221564579"
+      }
+    ],
+    "creationTime": "2018-10-04T11:07.000Z",
+    "egaStableId": "EGAC00001001033",
+    "published": true,
+    "released": "RELEASED",
+    "title": "T-ALL research group at the University Hospital in Heidelberg, Germany",
+    "url": "not provided"
+  },
+  {
+    "alias": "ena-DAC-EMBL-06-12-2018-01:42:26:025-259",
+    "centerName": "EGAB00000001577",
+    "contacts": [
+      {
+        "contactName": "Andreas Kulozik",
+        "email": "andreas.kulozik@med.uni-heidelberg.de",
+        "mainContact": false,
+        "organisation": "University of Heidelberg",
+        "phoneNumber": "+496221564500"
+      },
+      {
+        "contactName": "Jan Korbel",
+        "email": "korbel@embl.de",
+        "mainContact": true,
+        "organisation": "European Molecular Biology Laboratory (EMBL)",
+        "phoneNumber": "+4962213878822"
+      }
+    ],
+    "creationTime": "2018-12-06T00:29.000Z",
+    "egaStableId": "EGAC00001001091",
+    "published": true,
+    "released": "RELEASED",
+    "title": "EMBL genome biology research group for structural variation (Strand-seq application)",
+    "url": "not provided"
+  },
+  {
+    "alias": "a314bf37-8fd7-42f6-acfc-1926343abc38",
+    "centerName": "EGAB00000001581",
+    "contacts": [
+      {
+        "contactName": "Matthias Ebert",
+        "email": "matthias.ebert@medma.uni-heidelberg.de",
+        "mainContact": false,
+        "organisation": "Heidelberg University",
+        "phoneNumber": "+496213833284"
+      },
+      {
+        "contactName": "Michael Boutros",
+        "email": "m.boutros@dkfz.de",
+        "mainContact": true,
+        "organisation": "German Cancer Research Center (DKFZ)",
+        "phoneNumber": "+496221421950"
+      }
+    ],
+    "creationTime": "2019-01-15T10:23.000Z",
+    "egaStableId": "EGAC00001001113",
+    "published": true,
+    "released": "RELEASED",
+    "title": "Mannheim Liquid Biopsy Unit, Heidelberg University &amp; DKFZ",
+    "url": "NA"
+  },
+  {
+    "alias": "e7608108-a7eb-4475-b60c-974b916fb8fb",
+    "centerName": "EGAB00000001768",
+    "contacts": [
+      {
+        "contactName": "Eva Kathrin Roth",
+        "email": "eva.roth@med.uni-heidelberg.de",
+        "mainContact": true,
+        "organisation": "Department of Pediatric Oncology, Hematology and Immunology and Hopp Children’s Cancer Center at the NCT Heidelberg (KiTZ), University of Heidelberg, Heidelberg, Germany ",
+        "phoneNumber": "+4962215636967"
+      }
+    ],
+    "creationTime": "2019-10-01T06:03.000Z",
+    "egaStableId": "EGAC00001001337",
+    "published": true,
+    "released": "RELEASED",
+    "title": "Osteosarcoma Study HD Data Access Commitee",
+    "url": "NA"
+  }
+]

--- a/ega-examples/original/datasets.json
+++ b/ega-examples/original/datasets.json
@@ -1,0 +1,2180 @@
+[
+  {
+    "accessType": "CONTROLLED",
+    "alias": "DATA_SET_Coverage_bias_sensitivity_of_variant_calling_for_4_WG_seq_tech",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2012-05-08T06:34.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "sample"
+    ],
+    "description": "DATA_SET_Coverage_bias_sensitivity_of_variant_calling_for_4_WG_seq_tech",
+    "egaStableId": "EGAD00001000174",
+    "files": null,
+    "numSamples": 4,
+    "policyStableId": "EGAP00001000221",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2015-05-26T22:00.000Z",
+    "technology": [
+      "AB SOLiD 4 System",
+      "Complete Genomics",
+      "Illumina HiSeq 2000",
+      "unspecified"
+    ],
+    "title": "DATA_SET_Coverage_bias_sensitivity_of_variant_calling_for_4_WG_seq_tech"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "DATA_SET_marlboro-EEP-2013-03-15",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2013-03-27T14:53.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Methylation profiling by high-throughput sequencing"
+    ],
+    "description": "WGBS data of whole blood samples from smoking and non-smoking mothers and their children at gestation/birth and follow-up years.",
+    "egaStableId": "EGAD00001000366",
+    "files": null,
+    "numSamples": 52,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-07-04T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "Whole genome bisufite sequencing for smoking and non-smoking mother-child pairs"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-17-07-2014-15:54:18:121-70",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2014-07-17T13:34.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "In order to elucidate whether newly acquired genetic alterations during serial transplantation of patient derived primary pancreatic cancer cultures contribute to the observed clonal dynamics in vivo, all coding genes of two patient derived primary cultures and derived genetically marked serial xenografts (1°/2°/3°) were sequenced.",
+    "egaStableId": "EGAD00001000884",
+    "files": null,
+    "numSamples": 10,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-03-28T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "Exome sequencing of serially transplanted genetically marked IC-enriched primary PDAC cultures."
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-01-08-2014-08:47:40:399-28",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2014-08-01T06:01.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "Exome sequencing of sporadic schwannomatosis patients",
+    "egaStableId": "EGAD00001000963",
+    "files": null,
+    "numSamples": 16,
+    "policyStableId": "EGAP00001000221",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2015-05-26T22:00.000Z",
+    "technology": [],
+    "title": "Schwannomatosis WES data"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-01-08-2014-08:50:46:817-29",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2014-08-01T06:55.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "Low-coverage whole genome sequencing of sporadic schwannomatosis patients",
+    "egaStableId": "EGAD00001000964",
+    "files": null,
+    "numSamples": 16,
+    "policyStableId": "EGAP00001000221",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2015-05-26T22:00.000Z",
+    "technology": [],
+    "title": "Schwannomatosis lcWGS data"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-01-08-2014-15:53:49:885-84",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2014-08-01T13:59.000Z",
+    "dacs": [
+      "EGAC00001000217"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Methylation profiling by high-throughput sequencing"
+    ],
+    "description": "Whole genome bisulfite sequencing data for 6 ependymomas plus 3 fetal controls (f1, f2, f4) and 3 adult controls (a2, a3, a4). See Mack, Witt et al. Nature 506(7489):445-50, 2014 (PMID: 24553142).",
+    "egaStableId": "EGAD00001000966",
+    "files": null,
+    "numSamples": 14,
+    "policyStableId": "EGAP00001000220",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2015-05-26T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "WGBS data for ependymomas and normal controls (fetal and adult)"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-28-08-2014-13:48:51:420-1011",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2014-08-28T11:02.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "HIPO blastemal Wilms (nephroblastoma) characterisation of tumor driving events caused by differential SIX1 binding of the SIX1 Q177R mutatns",
+    "egaStableId": "EGAD00001000992",
+    "files": null,
+    "numSamples": 3,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-03-28T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "HIPO blastemal Wilms (nephroblastoma) CHIP sequencing samples"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-28-08-2014-14:05:04:574-1012",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2014-08-28T12:15.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Transcriptome profiling by high-throughput sequencing"
+    ],
+    "description": "HIPO blastemal Wilms (nephroblastoma) characterisation of tumor driving gene expression events",
+    "egaStableId": "EGAD00001000993",
+    "files": null,
+    "numSamples": 40,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-03-28T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "HIPO blastemal Wilms (nephroblastoma) RNA sequencing samples"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-28-08-2014-14:11:35:869-1013",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2014-08-28T12:46.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "HIPO blastemal Wilms (nephroblastoma) characterisation of tumor driving chromosomal aberrations",
+    "egaStableId": "EGAD00001000994",
+    "files": null,
+    "numSamples": 56,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-03-28T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000",
+      "Illumina HiSeq 2500"
+    ],
+    "title": "HIPO blastemal Wilms (nephroblastoma) WGS sequencing samples"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-28-08-2014-14:27:15:311-1014",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2014-08-28T12:27.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "HIPO blastemal Wilms (nephroblastoma) characterisation of tumor driving DNA alterations",
+    "egaStableId": "EGAD00001000995",
+    "files": null,
+    "numSamples": 112,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-03-28T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "HIPO blastemal Wilms (nephroblastoma) exome sequencing samples"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-29-08-2014-08:27:40:831-1015",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2014-08-29T06:50.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "Whole-exome sequencing of a chronic lymphocytic leukemia (CLL) developed during vemurafenib treatment of a patient with malignant melanoma. Peripheral blood mononuclear cells were separated by Ficoll gradient centrifugation. DNA was extracted from highly purified (&gt;97%) CD19+CD5+ cells obtained from the patient while being under BRAF inhibition versus CD14+ germline control cells (&gt;90% purity). No alterations that could be linked to aberrant RAS activity or paradoxical RAF/MEK/ERK signaling could be identified in the CLL, which shows characteristic copy number alterations.",
+    "egaStableId": "EGAD00001000997",
+    "files": null,
+    "numSamples": 2,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-03-28T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "Chronic lymphocytic leukemia driven by paradoxical ERK activation during BRAF inhibitor treatment"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-28-05-2015-11:13:32:451-82",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2015-05-28T09:43.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "sample"
+    ],
+    "description": "Mutations that activate the RAF-MEK-ERK signaling pathway, in particular BRAFV600E, occur in many cancers, and mutant BRAF-selective inhibitors have clinical activity in these diseases. Activating BRAF alleles are usually considered to be mutually exclusive with mutant RAS, whereas inactivating mutations in the D594F595G596 motif of the BRAF activation segment can coexist with oncogenic RAS and cooperate via paradoxical MEK/ERK activation. We determined the functional consequences of a largely uncharacterized BRAF mutation, F595L, which was detected along with an HRASQ61R allele by clinical exome sequencing in a patient with histiocytic sarcoma and also occurs in epithelial cancers, melanoma, and neuroblastoma, and investigated its interaction with mutant RAS. We demonstrate that, unlike previously described DFG motif mutants, BRAFF595L is a gain-of-function variant with intermediate activity towards MEK that does not act paradoxically, but nevertheless cooperates with mutant RAS to promote oncogenic signaling. Of immediate clinical relevance, BRAFF595L shows divergent responses to different mutant BRAF-selective inhibitors, whereas signaling driven by BRAFF595L with and without mutant RAS is efficiently blocked by pan-RAF and MEK inhibitors. Mutation data from primary patient samples and cell lines show that BRAFF595L, as well as other BRAF mutations with intermediate activity, frequently coincide with mutant RAS in a broad spectrum of cancers. These data define a novel class of activating BRAF mutations that cooperate with oncogenic RAS in a non-paradoxical fashion to achieve an optimal level of MEK-ERK signaling, extend the spectrum of patients with systemic histiocytic disorders and other malignancies who are candidates for therapeutic blockade of the RAF-MEK-ERK pathway, and underscore the value of comprehensive genetic profiling for understanding the signaling requirements of individual cancers.",
+    "egaStableId": "EGAD00001001384",
+    "files": null,
+    "numSamples": 2,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-03-28T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "Cooperative activity of BRAF F595L and mutant HRAS in histiocytic sarcoma provides new insights into oncogenic BRAF signaling"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-01-06-2015-13:43:18:542-193",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2015-06-01T11:33.000Z",
+    "dacs": [
+      "EGAC00001000346"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "Whole Genome Sequencing of Huh7 cell lines",
+    "egaStableId": "EGAD00001001386",
+    "files": null,
+    "numSamples": 2,
+    "policyStableId": "EGAP00001000335",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-07-26T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000",
+      "Illumina HiSeq 2500"
+    ],
+    "title": "WGS Huh7 cell lines"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-21-07-2015-14:09:30:309-81",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2015-07-21T12:53.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing",
+      "Transcriptome profiling by high-throughput sequencing",
+      "Methylation profiling by high-throughput sequencing"
+    ],
+    "description": "Atypical teratoid/rhabdoid tumor (ATRT) is one of the most common brain tumors in infants and young children. Although the prognosis of ATRT patients is poor, some patients respond very well to current treatments, suggesting inter-tumor molecular heterogeneity. To investigate this further, we genetically and epigenetically analyzed a large cohort of ATRTs (n = 170). Three distinct molecular subgroups of ATRTs, associated with differences in demographics, tumor location and type of SMARCB1 alterations, were identified using DNA-methylation or gene expression analyses. Whole genome DNA- and RNA-sequencing found no other recurrent mutations explaining the differences between subgroups. However, whole genome bisulfite-sequencing and H3K27Ac ChIP-sequencing of primary tumors revealed clear differences in methylation patterns and enhancer landscapes, leading to the identification of subgroup-specific regulatory networks.",
+    "egaStableId": "EGAD00001001444",
+    "files": null,
+    "numSamples": 55,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-03-28T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000",
+      "Illumina HiSeq 2500"
+    ],
+    "title": "Atypical teratoid/rhabdoid tumors (ATRT) are comprised of three epigenetic subgroups with distinct enhancer landscapes"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-17-08-2015-09:13:01:216-19",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2015-08-17T07:17.000Z",
+    "dacs": [
+      "EGAC00001000381"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Transcriptome profiling by high-throughput sequencing"
+    ],
+    "description": "PAR-CLIP was performed on the Argonaute-2 protein (AGO2) in four lymphoma cell lines:NamalwaRajiSU-DHL-4SU-DHL-6",
+    "egaStableId": "EGAD00001001468",
+    "files": null,
+    "numSamples": 4,
+    "policyStableId": "EGAP00001000369",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-10-12T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "Four lymphoma cell lines (AGO2-PAR-CLIP)"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-28-08-2015-09:49:06:632-229",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2015-08-28T07:20.000Z",
+    "dacs": [
+      "EGAC00001000381"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "sample"
+    ],
+    "description": "RNA-sequencing data from teh hT-RPE-MycER cell line after MYC activation and after MINCR knock-down in conditions of MYC ON or OFF",
+    "egaStableId": "EGAD00001001598",
+    "files": null,
+    "numSamples": 18,
+    "policyStableId": "EGAP00001000369",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2015-09-07T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "MYC and MINCR-regulated lncRNAs in hT-RPE-MycER cells"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-16-09-2015-13:05:30:578-414",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2015-09-16T11:46.000Z",
+    "dacs": [
+      "EGAC00001000381"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Transcriptome profiling by high-throughput sequencing"
+    ],
+    "description": "After overexpression and knockdown of both described novel miRs nmiR-1 and nmiR-2 in BL cell lines (SU-DHL4 for nmiR-1 and Raji for nmiR-2), we performed regular RNA-Seq (including Mock controls for all cell lines) to identify their direct and indirect downstream mRNA targets.",
+    "egaStableId": "EGAD00001001612",
+    "files": null,
+    "numSamples": 16,
+    "policyStableId": "EGAP00001000369",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-10-12T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "RNA-Seq of novel miR (nmiR-1 and nmiR-2) overexpression and knockdown in BL"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-12-04-2016-13:32:15:134-286",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2016-04-12T13:46.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Transcriptome profiling by high-throughput sequencing"
+    ],
+    "description": "RNA sequencing data of whole blood samples from smoking and non-smoking mothers and their children at gestation/birth and follow-up years.",
+    "egaStableId": "EGAD00001002011",
+    "files": null,
+    "numSamples": 64,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-04-19T22:00.000Z",
+    "technology": [],
+    "title": "RNA sequencing data of child-mother pairs, maternal smoking."
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-12-04-2016-13:35:10:904-287",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2016-04-12T13:46.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "sample"
+    ],
+    "description": "ChIPseq data of whole blood samples from smoking and non-smoking mothers and their children at gestation/birth and follow-up years.",
+    "egaStableId": "EGAD00001002012",
+    "files": null,
+    "numSamples": 16,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-04-19T22:00.000Z",
+    "technology": [],
+    "title": "ChIPseq data of child-mother pairs, maternal smoking."
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-22-04-2016-18:03:44:927-11",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-04-22T16:03.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "Whole exome sequencing from matched tumor-control samples of 121 primary lymphoma samples. Sequencing was performed on Illumina HiSeq2000. The dataset contains FASTQ files.",
+    "egaStableId": "EGAD00001002055",
+    "files": null,
+    "numSamples": 242,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-05-01T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "H005 WES CLL"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-22-04-2016-18:09:52:421-12",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-04-22T16:58.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Transcriptome profiling by high-throughput sequencing"
+    ],
+    "description": "Paired-end RNA sequencing using total RNA from 136 primary lymphoma samples. Sequencing was performed on the Illumina HiSeq2000 with 300bp insert size. The dataset contains FASTQ files.",
+    "egaStableId": "EGAD00001002056",
+    "files": null,
+    "numSamples": 136,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-05-01T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "H005 RNA-seq CLL"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-MUO-27-04-2016-12:33:45:301-16",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "MUO",
+    "creationTime": "2016-04-27T13:47.000Z",
+    "dacs": [
+      "EGAC00001000470"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "Renal cell carcinoma (RCC) is a genomically heterogeneous tumor. In the present project, the question whether intratumoral heterogeneity follows a zonal pattern indicating spatial niches was addressed. Whole exome sequencing of 16 paired samples from tumor periphery and center revealed a number of region-specific functional SNVs and Indels. Therefore, RCCs are not composed of evenly admixed tumor cells but show topological differences in their clonal composition.",
+    "egaStableId": "EGAD00001002067",
+    "files": null,
+    "numSamples": 16,
+    "policyStableId": "EGAP00001000456",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-08-22T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "Analysis of tumor periphery and center-specific mutations in renal cell carcinoma"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-18-05-2016-08:44:36:254-32",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2016-05-18T11:03.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "sample"
+    ],
+    "description": "ChIPseq data of Atypical teratoid/rhabdoid tumors (ATRT)",
+    "egaStableId": "EGAD00001002135",
+    "files": null,
+    "numSamples": 15,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-06-21T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000",
+      "Illumina HiSeq 2500"
+    ],
+    "title": "ChIPseq data of Atypical teratoid/rhabdoid tumors (ATRT)"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-18-05-2016-08:48:45:674-33",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2016-05-18T11:03.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Transcriptome profiling by high-throughput sequencing"
+    ],
+    "description": "RNA sequencing data of Atypical teratoid/rhabdoid tumors (ATRT)",
+    "egaStableId": "EGAD00001002136",
+    "files": null,
+    "numSamples": 25,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-06-21T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "RNA sequencing data of Atypical teratoid/rhabdoid tumors (ATRT)"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-18-05-2016-08:53:46:927-34",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2016-05-18T11:03.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Methylation profiling by high-throughput sequencing"
+    ],
+    "description": "WGBS data of Atypical teratoid/rhabdoid tumors (ATRT)",
+    "egaStableId": "EGAD00001002137",
+    "files": null,
+    "numSamples": 15,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-06-21T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000",
+      "Illumina HiSeq 2500"
+    ],
+    "title": "WGBS data of Atypical teratoid/rhabdoid tumors (ATRT)"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-IBIOS-18-05-2016-08:57:29:419-35",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2016-05-18T11:02.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "WGS data of Atypical teratoid/rhabdoid tumors (ATRT)",
+    "egaStableId": "EGAD00001002138",
+    "files": null,
+    "numSamples": 36,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-06-21T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "WGS data of Atypical teratoid/rhabdoid tumors (ATRT)"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-02-06-2016-16:14:01:314-131",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-06-07T13:11.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "Exome Seq for Study EGAS00001001844",
+    "egaStableId": "EGAD00001002159",
+    "files": null,
+    "numSamples": 2,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-07-10T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "Exome"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-02-06-2016-16:16:09:098-133",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-06-07T13:11.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "Exome Seq for EGAS00001001845",
+    "egaStableId": "EGAD00001002160",
+    "files": null,
+    "numSamples": 2,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-07-10T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "Exome"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-02-06-2016-16:17:30:684-137",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-06-07T13:11.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Transcriptome profiling by high-throughput sequencing"
+    ],
+    "description": "Transcriptome from EGAS00001001845",
+    "egaStableId": "EGAD00001002161",
+    "files": null,
+    "numSamples": 1,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-07-10T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "Transcriptome"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-02-06-2016-16:18:51:312-138",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-06-07T13:11.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "Exome Seq from EGAS00001001846",
+    "egaStableId": "EGAD00001002162",
+    "files": null,
+    "numSamples": 2,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-07-10T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "Exome"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-02-06-2016-16:19:57:504-139",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-06-07T13:10.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Transcriptome profiling by high-throughput sequencing"
+    ],
+    "description": "Transcriptome from EGAS00001001846",
+    "egaStableId": "EGAD00001002163",
+    "files": null,
+    "numSamples": 1,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-07-10T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "Transcriptome"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-02-06-2016-16:21:01:191-140",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-06-07T13:10.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "Exome from EGA00001001848",
+    "egaStableId": "EGAD00001002164",
+    "files": null,
+    "numSamples": 2,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-07-10T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "Exome"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-06-06-2016-09:38:03:185-52",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-06-06T07:05.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "Exome from EGAS00001001861",
+    "egaStableId": "EGAD00001002166",
+    "files": null,
+    "numSamples": 17,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-06-11T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "Clear cell renal cell carcinoma (HIPO-045)"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-16-08-2016-09:06:02:030-345",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-08-16T07:07.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "WGS from EGAS00001001857",
+    "egaStableId": "EGAD00001002528",
+    "files": null,
+    "numSamples": 18,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2017-05-28T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "HIPO-P002 Whole genome"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-Neuromics-22-09-2016-08:49:06:149-211",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "Neuromics",
+    "creationTime": "2016-09-22T06:10.000Z",
+    "dacs": [
+      "EGAC00001000165"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "48 samples from the TRACK-HD cohort. All samples carry the Huntington’s disease expansion. The subjects were selected on the basis of rate of disease progression.",
+    "egaStableId": "EGAD00001002695",
+    "files": null,
+    "numSamples": 48,
+    "policyStableId": "EGAP00001000171",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "NeurOmics_HD_Modifier_V1"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-Neuromics-22-09-2016-09:32:18:368-213",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "Neuromics",
+    "creationTime": "2016-09-22T07:20.000Z",
+    "dacs": [
+      "EGAC00001000165"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Transcriptome profiling by high-throughput sequencing"
+    ],
+    "description": "This data set includes RNAseq data from 136 samples from the TRACK-HD cohort including premanifest, manifest and control subjects. \nData can only be used for Huntington's disease related research.",
+    "egaStableId": "EGAD00001002699",
+    "files": null,
+    "numSamples": 136,
+    "policyStableId": "EGAP00001000171",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "NeurOmics_HD_Biomarker-1_V1"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "Small RNA sequencing of blood plasma-derived exosomes from CLL",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ",
+    "creationTime": "2017-03-17T13:19.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "Small RNA expression profiles of the blood plasma-derived exosomes from B-cell chronic lymphocytic leukemia patients",
+    "egaStableId": "EGAD00001003230",
+    "files": null,
+    "numSamples": 3,
+    "policyStableId": "EGAP00001000221",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2017-07-17T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "Tumor-derived exosomes modulate PD-L1 expression in monocytes"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-09-05-2017-15:55:17:146-277",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2017-05-09T13:19.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "Exome from EGAS00001002441",
+    "egaStableId": "EGAD00001003325",
+    "files": null,
+    "numSamples": 2,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "Exome"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-06-07-2017-16:10:50:154-493",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ",
+    "creationTime": "2017-07-06T14:53.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "RNA analysis of two patients 11 and 15 with WGS done on Illumina HiSeq2000. For research purpose and authorised user only.",
+    "egaStableId": "EGAD00001003429",
+    "files": null,
+    "numSamples": 2,
+    "policyStableId": "EGAP00001000221",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2017-08-29T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "RNA-Seq Pair End"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-06-07-2017-17:03:52:162-505",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ",
+    "creationTime": "2017-07-06T15:54.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "RNA analysis of six patients 34, 35, 36, 37, 38 and 39 with WGS done on Illumina HiSeq2500. For research purpose and authorised user only.",
+    "egaStableId": "EGAD00001003430",
+    "files": null,
+    "numSamples": 6,
+    "policyStableId": "EGAP00001000221",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2017-08-29T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "RNA-Seq Single End"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-10-07-2017-14:51:26:287-19",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ",
+    "creationTime": "2017-07-10T12:29.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "Seven files of patients 3, 21, 29, 30, 31, 32 and 33 with WGS done on Illumina MiSeq with high coverage. For research purpose and authorised user only.",
+    "egaStableId": "EGAD00001003436",
+    "files": null,
+    "numSamples": 7,
+    "policyStableId": "EGAP00001000221",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2017-08-29T22:00.000Z",
+    "technology": [
+      "Illumina MiSeq"
+    ],
+    "title": "MiSeq-High Coverage"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-10-07-2017-14:56:28:042-20",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ",
+    "creationTime": "2017-07-10T12:30.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "Fourteen files of patients 1, 2, 4, 6, 7, 8, 9, 12, 14, 16, 17, 18, 19 and 27 with WGS done on Illumina MiSeq with low coverage. For research purpose and authorised user only.",
+    "egaStableId": "EGAD00001003437",
+    "files": null,
+    "numSamples": 14,
+    "policyStableId": "EGAP00001000221",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2017-08-29T22:00.000Z",
+    "technology": [
+      "Illumina MiSeq"
+    ],
+    "title": "MiSeq-Low Coverage"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-10-07-2017-15:00:31:755-21",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ",
+    "creationTime": "2017-07-10T13:33.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "Three files of patients 20, 23 and 25  with WGS done on Illumina HiSeq 2000. For research purpose and authorised user only.",
+    "egaStableId": "EGAD00001003438",
+    "files": null,
+    "numSamples": 3,
+    "policyStableId": "EGAP00001000221",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2017-08-29T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "Illumina HiSeq 2000"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-10-07-2017-15:01:36:723-22",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ",
+    "creationTime": "2017-07-10T13:38.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "Three files of patients 10, 11 and 13 with WGS done on Illumina HiSeq X Ten. For research purpose and authorised user only.",
+    "egaStableId": "EGAD00001003439",
+    "files": null,
+    "numSamples": 3,
+    "policyStableId": "EGAP00001000221",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2017-08-29T22:00.000Z",
+    "technology": [
+      "HiSeq X Ten"
+    ],
+    "title": "Illumina HiSeq X Ten"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-10-07-2017-15:06:02:958-23",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ",
+    "creationTime": "2017-07-10T13:04.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "One file of patient 16 with WGS done on Illumina HiSeq X-Ten. For research purpose and authorised user only.",
+    "egaStableId": "EGAD00001003440",
+    "files": null,
+    "numSamples": 1,
+    "policyStableId": "EGAP00001000221",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2017-08-29T22:00.000Z",
+    "technology": [
+      "HiSeq X Ten"
+    ],
+    "title": "Patient 16CH"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-dkfz_b062-04-08-2017-13:47:34:208-1428",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "dkfz_b062",
+    "creationTime": "2017-08-04T11:36.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "Whole exome sequencing data to 30 PDOX models (28 early passages, 3 late passages (1 overlap)), 3 cell lines, and 20 matching human tumors",
+    "egaStableId": "EGAD00001003544",
+    "files": null,
+    "numSamples": 53,
+    "policyStableId": "EGAP00001000687",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-01-28T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000",
+      "Illumina HiSeq 4000"
+    ],
+    "title": "Whole exome genome sequencing data to study \"A biobank of patient-derived pediatric brain tumor models\""
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-dkfz_b062-04-08-2017-14:15:21:871-1439",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "dkfz_b062",
+    "creationTime": "2017-08-04T12:23.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "Low-coverage whole genome sequencing data for 30 PDOX models (28 early passages, 4 late passages (2 overlaps)), 3 cell lines, and 21 matching human tumors",
+    "egaStableId": "EGAD00001003545",
+    "files": null,
+    "numSamples": 56,
+    "policyStableId": "EGAP00001000687",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-01-28T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "Low-coverage whole genome sequencing data to study \"A biobank of patient-derived pediatric brain tumor models\""
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-dkfz_b062-18-08-2017-15:54:03:183-161",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "dkfz_b062",
+    "creationTime": "2017-08-18T13:04.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Transcriptome profiling by high-throughput sequencing"
+    ],
+    "description": "RNA sequencing data for the PDOX model EPD-613FH",
+    "egaStableId": "EGAD00001003573",
+    "files": null,
+    "numSamples": 1,
+    "policyStableId": "EGAP00001000687",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-01-28T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "RNA sequencing data to study \"A biobank of patient-derived pediatric braintumor models\""
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-01-12-2017-12:36:36:554-60",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2017-12-01T11:38.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "The data set contains bam files aligned using bwa-0.7.8 mem -t 8 -R.",
+    "egaStableId": "EGAD00001003827",
+    "files": null,
+    "numSamples": 4,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2017-12-12T23:00.000Z",
+    "technology": [
+      "HiSeq X Ten"
+    ],
+    "title": "whole genome sequencing data of LMS cell lines"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-01-12-2017-13:02:22:609-63",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2017-12-01T12:24.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Transcriptome profiling by high-throughput sequencing"
+    ],
+    "description": "This dataset contains paired fastq files for LMS tumor samples",
+    "egaStableId": "EGAD00001003828",
+    "files": null,
+    "numSamples": 37,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000",
+      "Illumina HiSeq 2500"
+    ],
+    "title": "RNA-seq data of LMS tumors"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-01-12-2017-13:14:23:391-67",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2017-12-01T12:25.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "The data set contains paired end fastq files for whole exome sequencing data for Leiomyosarcoma tumor and control samples",
+    "egaStableId": "EGAD00001003829",
+    "files": null,
+    "numSamples": 96,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2017-12-12T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000",
+      "Illumina HiSeq 2500"
+    ],
+    "title": "Exome sequencing data for LMS tumor and control samples"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-dkfz_b062-31-01-2018-17:04:38:652-360",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "dkfz_b062",
+    "creationTime": "2018-01-31T16:44.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "This dataset contains whole genome sequencing data from 24 patients. For each patient a tumour and control sample has been sequenced on a Illumina HiSeq2000 instrument in paired-end mode. Up to three lanes per sample have been sequenced resulting in 112 Fastq files.",
+    "egaStableId": "EGAD00001003940",
+    "files": null,
+    "numSamples": 48,
+    "policyStableId": "EGAP00001000221",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "Whole genome sequencing data to study therapeutic targeting of ependymoma"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-16-02-2018-09:13:54:127-321",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2018-02-16T08:00.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "Whole genome sequencing of Control (blood), Tumor and metastasis triplets for 12 samples.",
+    "egaStableId": "EGAD00001003965",
+    "files": null,
+    "numSamples": 36,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-02-23T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "Hipo-032 Metastasome of Colorectal Cancer"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-dkfz_b062-16-02-2018-17:18:40:151-347",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "dkfz_b062",
+    "creationTime": "2018-02-16T16:42.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Transcriptome profiling by high-throughput sequencing"
+    ],
+    "description": "This dataset conatains RNA sequencing data from 24 patients. Up to two lanes per tumour sample have been seqeunced on a Illumina HiSeq2000 instrument in paired-end mode resulting in 58 Fastq files.",
+    "egaStableId": "EGAD00001003966",
+    "files": null,
+    "numSamples": 24,
+    "policyStableId": "EGAP00001000221",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "RNA sequencing data to study therapeutic targeting of ependymoma"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-dkfz_b062-21-02-2018-14:40:33:479-591",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "dkfz_b062",
+    "creationTime": "2018-02-21T13:35.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "This dataset contains whole exome sequencing data from 24 patients. The Agilent SureSelect Human All Exon 50-Mb target enrichment kit was used to capture all human exons for deep sequencing. For each patient a tumour and control sample has been sequenced on a Illumina HiSeq2000 instrument in paired-end mode. Up to three lanes per sample have been sequenced resulting in 118 Fastq files.",
+    "egaStableId": "EGAD00001003973",
+    "files": null,
+    "numSamples": 48,
+    "policyStableId": "EGAP00001000221",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "Exome sequencing data to study therapeutic targeting of ependymoma"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-dkfz_b062-23-02-2018-16:41:10:412-192",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "dkfz_b062",
+    "creationTime": "2018-02-23T15:12.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Chip-Seq"
+    ],
+    "description": "This dataset contains ChIP sequencing data from 24 patients. ChIP of 5–10 mg flash-frozen primary ependymoma tumour was performed using 5 mg H3K27ac antibody per ChIP experiment. The enriched DNA has been sequenced on a Illumina HiSeq2000 instrument in paired-end mode. Up to two lanes per sample have been sequenced resulting in 70 Fastq files.",
+    "egaStableId": "EGAD00001003979",
+    "files": null,
+    "numSamples": 24,
+    "policyStableId": "EGAP00001000221",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "ChIP sequencing data to study therapeutic targeting of ependymoma"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-06-04-2018-11:32:22:895-1684",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2018-04-06T09:24.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing",
+      "Exome sequencing",
+      "Transcriptome profiling by high-throughput sequencing"
+    ],
+    "description": "Whole-genome, whole-exome and transcriptome sequencing of pancreatic ductal adenocarcinomas from young adults reveals recurrent NRG1-fusions in KRAS wild-type tumors.",
+    "egaStableId": "EGAD00001004068",
+    "files": null,
+    "numSamples": 36,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "HiSeq X Ten",
+      "Illumina HiSeq 2500",
+      "Illumina HiSeq 4000"
+    ],
+    "title": "Whole-genome, whole-exome and transcriptome sequencing of pancreatic ductal adenocarcinomas from young adults (NCT MASTER)"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "2177fcf0-fe86-4de1-8a7b-02b67f71c3d5",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "CRG",
+    "creationTime": "2018-05-25T12:52.000Z",
+    "dacs": [
+      "EGAC00001000916"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing",
+      "Genomic variant calling"
+    ],
+    "description": "This dataset has two Variants Files in VCF format used in ABB project (https://github.com/Francesc-Muyas/ABB). \nOne has the variants found in a Rare Variant Association Study performed in CLL patients. This has 1217 samples represented. \nThe other variant file has 209 SNPs predicted in 10 samples by GATK HaplotypeCaller and selected for Sanger Sequencing Validation.\nRaw reads were aligned against the Human Reference genome (Hg19) with BWA mem and variants were obtained using GATK HaplotypeCaller.",
+    "egaStableId": "EGAD00001004132",
+    "files": null,
+    "numSamples": 1217,
+    "policyStableId": "EGAP00001000889",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [],
+    "title": "Variant Calling used in ABB project"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "c4c9db5f-364e-46c3-8cce-015b4d9b26a6",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "EGAB00000001489",
+    "creationTime": "2018-08-27T11:29.000Z",
+    "dacs": [
+      "EGAC00001000998"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Amplicon sequencing"
+    ],
+    "description": "The dataset includes 19 bam files. Each bam file is a different colorectal cancer patient organoid.",
+    "egaStableId": "EGAD00001004313",
+    "files": null,
+    "numSamples": 19,
+    "policyStableId": "EGAP00001000962",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "Illumina MiSeq"
+    ],
+    "title": "Amplicon sequencing data from organoids of colorectal cancer patients."
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "5cd543ac-f5b2-4d5f-b5db-e9357e087477",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "EGAB00000001518",
+    "creationTime": "2018-11-14T12:21.000Z",
+    "dacs": [
+      "EGAC00001001033"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "Each dataset cosist of WES data from 5 samples (1 patient): original leukemia initial diagnosis T-ALL, original leukemia relapse T-ALL, PDX derived of initial diagnosis T-ALL, PDX derived of relapse T-ALL, remission (normal control)",
+    "egaStableId": "EGAD00001004459",
+    "files": null,
+    "numSamples": 60,
+    "policyStableId": "EGAP00001001035",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000",
+      "Illumina HiSeq 2500"
+    ],
+    "title": "WES of matched primary pediatric T-cell leukemias and PDXs"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-EMBL-06-12-2018-02:10:51:685-261",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "EGAB00000001577",
+    "creationTime": "2018-12-06T01:56.000Z",
+    "dacs": [
+      "EGAC00001001091"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "In this study, we aimed to identify somatic structural variation of T-cell acute lymphoblastic leukemias (T-ALLs_ from patient-derived xenografts (PDX) at the single-cell level. For this purpose, we performed strand-specific single-cell sequencing of PDX-derived T-ALL relapse samples from two juvenile patients  (P1, P33). To validate structural variation detected via scTRIP, we profiled whole exome sequencing (WES) data from P33 (samples taken during initial disease, remission, relapse), and mate-pair sequencing data from P1 (relapse).",
+    "egaStableId": "EGAD00001004499",
+    "files": null,
+    "numSamples": 124,
+    "policyStableId": "EGAP00001001056",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000",
+      "NextSeq 500"
+    ],
+    "title": "Finding structural variation from the patient-derived xenografts of pediatric T-cell leukemia at the single-cell level"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-16-01-2019-20:10:43:076-672",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2019-01-16T19:45.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "This dataset contains whole genome sequencing data from 21 primary and relapsed IDH-wt glioblastomas and matched blood controls. Tumors were sequenced at a target coverage of 150x, blood controls at 80x.",
+    "egaStableId": "EGAD00001004563",
+    "files": null,
+    "numSamples": 63,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "HiSeq X Ten"
+    ],
+    "title": "Whole genome sequencing of paired samples from primary and relapsed IDH-wt glioblastomas with matched blood controls"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-16-01-2019-20:19:26:486-673",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2019-01-16T19:28.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Transcriptome profiling by high-throughput sequencing"
+    ],
+    "description": "This dataset contains strand-specific RNA sequencing data from 16 primary/relapsed sample pairs of IDH-wt glioblastomas",
+    "egaStableId": "EGAD00001004564",
+    "files": null,
+    "numSamples": 32,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "Strand-specific RNA sequencing of 16 pairs of primary and relapsed IDH-wt glioblastomas"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "ena-DATASET-DKFZ-HIPO-16-01-2019-20:40:34:034-676",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2019-01-16T19:35.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Amplicon sequencing"
+    ],
+    "description": "This dataset contains gene panel sequencing data from 43 sample pairs of primary and relapsed IDH-wt glioblastomas. The gene panel covers 50 glioma-associated genes. 14 of the sequenced sample pairs were sequenced with whole genome sequencing also and are accessible under EGAD00001004563.",
+    "egaStableId": "EGAD00001004565",
+    "files": null,
+    "numSamples": 86,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "Ion Torrent Proton"
+    ],
+    "title": "Gene panel sequencing of paired samples from primary and relapsed IDH-wt glioblastomas"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "7d1d07e0-94fe-49b9-8055-92660cffd053",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "EGAB00000001581",
+    "creationTime": "2019-01-21T09:11.000Z",
+    "dacs": [
+      "EGAC00001001113"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Amplicon sequencing"
+    ],
+    "description": "The dataset consists of sequenced cell free DNA (cfDNA) samples from colorectal cancer patients. The samples were sequenced on an Illumina MiSeq machine using a custom amplicon sequencing approach. These amplicons were designed to cover the most common mutation hotspots in colorectal cancer. The data include 138 cfDNA samples from 34 different patients. For each patient several samples are available derived from blood drawn at different time points during treatment. In addition the data include samples from 22 histology slides and 30 samples derived from HT29/HCT116 cell lines that were used as controls.",
+    "egaStableId": "EGAD00001004574",
+    "files": null,
+    "numSamples": 189,
+    "policyStableId": "EGAP00001001086",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "Illumina MiSeq"
+    ],
+    "title": "Mannheim Liquid Biopsy Unit, Heidelberg University &amp; DKFZ"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "7687436a-e704-42d8-b3c9-ab87e961e2e0",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2019-03-06T11:09.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing",
+      "Exome sequencing"
+    ],
+    "description": "Case series of the rare tumor entity chordoma. 9 cases sequenced with Whole Exome Sequencing (WES) and 2 cases sequenced with Whole Genome Sequencing (WGS) were recruited from the personalized oncology program NCT-MASTER/DKTK-MASTER at the German Cancer Research Center. One of the WES patients was re-sequenced at a later time point when he relapsed, this resequencing was done by WGS. Therefore there are 11 patients, one of which with two samples, all of which were sequenced with matched normal controls, amounting to a total number of 24 NGS samples.",
+    "egaStableId": "EGAD00001004825",
+    "files": null,
+    "numSamples": 24,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "HiSeq X Ten",
+      "Illumina HiSeq 2500",
+      "Illumina HiSeq 4000"
+    ],
+    "title": "24 Chordoma samples (WES,WGS)"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "faa1d2f2-265c-462c-aff3-94cc4b356a90",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "MUO",
+    "creationTime": "2019-04-03T10:56.000Z",
+    "dacs": [
+      "EGAC00001000470"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "We performed multiregion whole exome sequencing of a total of 37 samples from five consecutive patients (normal tissue, n=5; primary tumors, n=16; tumor thrombi, n=16) to &gt;35-fold target coverage. Matching primary tumor and venous tumor thrombus samples were analyzed. Four patients had a clear cell RCC, one patient had a poorly differentiated type II papillary RCC (RCC-VTT-04). The latter patient had a friable thrombus, the others were of solid consistency.",
+    "egaStableId": "EGAD00001004887",
+    "files": null,
+    "numSamples": 37,
+    "policyStableId": "EGAP00001000456",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "Exome sequencing of matching primary tumor and venous tumor thrombus (VTT) renal cell carcinoma (RCC) samples"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "bc246e56-19ea-4c30-9e33-160ac12c3050",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "dkfz_b062",
+    "creationTime": "2019-05-15T11:35.000Z",
+    "dacs": [
+      "EGAC00001000219"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Chip-Seq"
+    ],
+    "description": "Bam files for 16 meningioma tumor samples; ChIPseq performed on Illumina HiSeq 2000",
+    "egaStableId": "EGAD00001005021",
+    "files": null,
+    "numSamples": 16,
+    "policyStableId": "EGAP00001000687",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2019-05-16T22:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2000"
+    ],
+    "title": "ChIPseq Sequencing data for epigenetic subgroups of meningioma"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "be40ebac-acee-4026-a661-4330bb0f657b",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2019-06-04T09:40.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing"
+    ],
+    "description": "Bam files for 124 samples (62 tumor vs blood pairs); Whole Genome Sequencing performed on Illumina HiSeq X Ten",
+    "egaStableId": "EGAD00001005061",
+    "files": null,
+    "numSamples": 124,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "HiSeq X Ten"
+    ],
+    "title": "Whole Genome Sequencing data for epigenetic subgroups of meningioma"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "69ab3410-fe23-42b3-a34e-a7f83ab902d8",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2019-06-27T11:29.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Whole genome sequencing",
+      "Exome sequencing",
+      "Transcriptome profiling by high-throughput sequencing"
+    ],
+    "description": "50 samples of 16 individuals with Gastrointestinal Tumor. Patients were sequenced in various combinations of WGS, Exome and RNA sequencing.",
+    "egaStableId": "EGAD00001005113",
+    "files": null,
+    "numSamples": 50,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "HiSeq X Ten",
+      "Illumina HiSeq 2500",
+      "Illumina HiSeq 4000"
+    ],
+    "title": "EGAS00001003405 combined RNA, WES, WGS data of 16 gastrointestinal tumor patients"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "c8abf99f-5f5a-46f4-b0a5-ba5d5dcf72ad",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2019-08-13T13:48.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing",
+      "Transcriptome profiling by high-throughput sequencing"
+    ],
+    "description": "Exome and RNA sequencing data for EGAS00001003776 - one female patient with neurofibroma/schwannoma hybrid nerve sheath tumor (N/S HNST)",
+    "egaStableId": "EGAD00001005249",
+    "files": null,
+    "numSamples": 2,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "Illumina HiSeq 2500"
+    ],
+    "title": "Exome and RNA seq data for female patient"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "164a2fdc-6bef-418c-82a7-2f24fd2a1bbf",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": "EGAB00000001768",
+    "creationTime": "2019-10-02T05:23.000Z",
+    "dacs": [
+      "EGAC00001001337"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "Exome sequencing"
+    ],
+    "description": "WES from two human osteosarcoma with two samples each from the corresponding cell line, BAM files",
+    "egaStableId": "EGAD00001005370",
+    "files": null,
+    "numSamples": 6,
+    "policyStableId": "EGAP00001001314",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2000-12-31T23:00.000Z",
+    "technology": [
+      "NextSeq 500"
+    ],
+    "title": "WES from two human osteosarcoma with two samples each from the corresponding cell line"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "Gencode_15K",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": null,
+    "creationTime": "2016-07-08T12:55.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "sample"
+    ],
+    "description": "Lymphoma samples using CytoSNP",
+    "egaStableId": "EGAD00010000947",
+    "files": null,
+    "numSamples": 35,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-04-28T22:00.000Z",
+    "technology": [
+      "Illumina CytoSNP"
+    ],
+    "title": "Gencode_15K"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "Gencode_500K",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": null,
+    "creationTime": "2016-07-08T12:55.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "sample"
+    ],
+    "description": "Lymphoma samples using 450k",
+    "egaStableId": "EGAD00010000948",
+    "files": null,
+    "numSamples": 95,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-04-28T22:00.000Z",
+    "technology": [
+      "Illumina 450k"
+    ],
+    "title": "Gencode_500K"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "Gencode_550K",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": null,
+    "creationTime": "2016-07-08T12:55.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "sample"
+    ],
+    "description": "Lymphoma samples using HumanOmni",
+    "egaStableId": "EGAD00010000949",
+    "files": null,
+    "numSamples": 104,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-04-28T22:00.000Z",
+    "technology": [
+      "Illumina HumanOmni2.5"
+    ],
+    "title": "Gencode_550K"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "Illumina_450K",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": null,
+    "creationTime": "2016-08-19T07:41.000Z",
+    "dacs": [
+      "EGAC00001000317"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "sample"
+    ],
+    "description": "Primary renal cell carcinoma (RCC), RCC metastases and cell lines by Illumina 450K",
+    "egaStableId": "EGAD00010001001",
+    "files": null,
+    "numSamples": 62,
+    "policyStableId": "EGAP00001000506",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-08-18T22:00.000Z",
+    "technology": [
+      "Illumina 450K"
+    ],
+    "title": "Illumina_450K"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "Affymetrix_miRNA4.0",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": null,
+    "creationTime": "2018-05-16T13:51.000Z",
+    "dacs": [
+      "EGAC00001000317"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "sample"
+    ],
+    "description": "Primary renal cell carcinoma (RCC) by Affymetrix GeneChip miRNA 4.0",
+    "egaStableId": "EGAD00010001564",
+    "files": null,
+    "numSamples": 56,
+    "policyStableId": "EGAP00001000506",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-05-16T22:00.000Z",
+    "technology": [
+      "Affymetrix GeneChip miRNA 4.0"
+    ],
+    "title": "Affymetrix_miRNA4.0"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "Affymetrix_HTA2.0",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": null,
+    "creationTime": "2018-07-28T14:00.000Z",
+    "dacs": [
+      "EGAC00001000317"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "sample"
+    ],
+    "description": "Primary renal cell carcinoma (RCC) and RCC metastases by Affymetrix GeneChip HTA 2.0",
+    "egaStableId": "EGAD00010001589",
+    "files": null,
+    "numSamples": 112,
+    "policyStableId": "EGAP00001000506",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-07-29T22:00.000Z",
+    "technology": [
+      "Affymetrix Human Transcriptome Array 2.0"
+    ],
+    "title": "Affymetrix_HTA2.0"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "EPIC DNA Methylation Array",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": null,
+    "creationTime": "2018-12-12T13:26.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "sample"
+    ],
+    "description": "",
+    "egaStableId": "EGAD00010001642",
+    "files": null,
+    "numSamples": 25,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2019-01-17T23:00.000Z",
+    "technology": [
+      "Illumina EPIC methylation bead array"
+    ],
+    "title": "EPIC DNA Methylation Array"
+  },
+  {
+    "accessType": "CONTROLLED",
+    "alias": "450k DNA Methylation Array",
+    "attributes": [],
+    "availableInBeacon": false,
+    "centerName": null,
+    "creationTime": "2018-12-12T13:26.000Z",
+    "dacs": [
+      "EGAC00001000452"
+    ],
+    "datasetLinks": [],
+    "datasetTypes": [
+      "sample"
+    ],
+    "description": "",
+    "egaStableId": "EGAD00010001643",
+    "files": null,
+    "numSamples": 73,
+    "policyStableId": "EGAP00001000441",
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2019-01-17T23:00.000Z",
+    "technology": [
+      "Illumina 450k methylation bead array"
+    ],
+    "title": "450k DNA Methylation Array"
+  }
+]

--- a/ega-examples/original/studies.json
+++ b/ega-examples/original/studies.json
@@ -1,0 +1,779 @@
+[
+  {
+    "alias": "Coverage_bias_sensitivity_of_variant_calling_for_4_WG_seq_tech",
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2012-04-23T07:13.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001000174"
+    ],
+    "description": "Massively parallel sequencing has revolutionized research in cancer genetics and genomics and enhanced our understanding of natural human genetic variation. Recently, Lam et al. have performed a detailed comparison of two next-generation sequencing technologies with respect to their sensitivity to call single nucleotide variants (SNV) and indels. Here, we sequenced two tumor/normal pairs obtained from two paedriatic medulloblastoma patients with Life Technologies’ SOLiD 4 and 5500xl SOLiD, Illumina’s HiSeq2000, and Complete Genomics’ technology.  We then compared their ability to call SNVs with high confidence. As gold standard for SNV calling, we used genotypes determined by an Affymetrix SNP array. Additionally, we performed a detailed analysis of how evenly each technology covers the genome and how the reads are distributed across functional genomic regions. Finally, we studied how a combination of data from different technologies might help to overcome the limitations in SNV calling by any of the four technologies alone.",
+    "egaStableId": "EGAS00001000274",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": null,
+    "studyAbstract": "Massively parallel sequencing has revolutionized research in cancer genetics and genomics and enhanced our understanding of natural human genetic variation. Recently, Lam et al. have performed a detailed comparison of two next-generation sequencing technologies with respect to their sensitivity to call single nucleotide variants (SNV) and indels. Here, we sequenced two tumor/normal pairs obtained from two paedriatic medulloblastoma patients with Life Technologies’ SOLiD 4 and 5500xl SOLiD, Illumina’s HiSeq2000, and Complete Genomics’ technology.  We then compared their ability to call SNVs with high confidence. As gold standard for SNV calling, we used genotypes determined by an Affymetrix SNP array. Additionally, we performed a detailed analysis of how evenly each technology covers the genome and how the reads are distributed across functional genomic regions. Finally, we studied how a combination of data from different technologies might help to overcome the limitations in SNV calling by any of the four technologies alone.",
+    "studyType": "Whole Genome Sequencing",
+    "title": "Coverage bias and sensitivity of variant calling for four whole-genome sequencing technologies"
+  },
+  {
+    "alias": "lindt_ependymoma_2013_02_28",
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2013-02-28T11:24.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001000966"
+    ],
+    "description": "Ependymomas are common childhood brain tumours that occur throughout the nervous system, but are most common in the paediatric hindbrain. Current standard therapy comprises surgery and radiation, but not cytotoxic chemotherapy as it does not further increase survival. Whole-genome and whole-exome sequencing of 47 hindbrain ependymomas reveals an extremely low mutation rate, and zero significant recurrent somatic single nucleotide variants. Although devoid of recurrent single nucleotide variants and focal copy number aberrations, poor-prognosis hindbrain ependymomas exhibit a CpG island methylator phenotype. Transcriptional silencing driven by CpG methylation converges exclusively on targets of the Polycomb repressive complex 2 which represses expression of differentiation genes through trimethylation of H3K27. CpG island methylator phenotype-positive hindbrain ependymomas are responsive to clinical drugs that target either DNA or H3K27 methylation both in vitro and in vivo. We conclude that epigenetic modifiers are the first rational therapeutic candidates for this deadly malignancy, which is epigenetically deregulated but genetically bland.",
+    "egaStableId": "EGAS00001000443",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": null,
+    "studyAbstract": "Ependymomas are common childhood brain tumours that occur throughout the nervous system, but are most common in the paediatric hindbrain. Current standard therapy comprises surgery and radiation, but not cytotoxic chemotherapy as it does not further increase survival. Whole-genome and whole-exome sequencing of 47 hindbrain ependymomas reveals an extremely low mutation rate, and zero significant recurrent somatic single nucleotide variants. Although devoid of recurrent single nucleotide variants and focal copy number aberrations, poor-prognosis hindbrain ependymomas exhibit a CpG island methylator phenotype. Transcriptional silencing driven by CpG methylation converges exclusively on targets of the Polycomb repressive complex 2 which represses expression of differentiation genes through trimethylation of H3K27. CpG island methylator phenotype-positive hindbrain ependymomas are responsive to clinical drugs that target either DNA or H3K27 methylation both in vitro and in vivo. We conclude that epigenetic modifiers are the first rational therapeutic candidates for this deadly malignancy, which is epigenetically deregulated but genetically bland.",
+    "studyType": "Other",
+    "title": "Epigenomic alterations define lethal CIMP-positive ependymomas of infancy"
+  },
+  {
+    "alias": "marlboro-EEP-2013-03-15",
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2013-03-15T12:31.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001000366",
+      "EGAD00001002011",
+      "EGAD00001002012"
+    ],
+    "description": "Whole-blood samples of 16 mother-child pairs with differing maternal smoking behaviour were bisulfite treated and sequenced with deep coverage to identify smoking-associated differentially methylated regions.RNA-sequencing and ChIP-sequencing of 4 chromatin marks complete the data set and allow for integrative analyses, functional region annotation and to study the impact of epigenetic changes on gene expression.Longitudinal data spanning several years provides the means to investigate the stability of observed differences of all data types.",
+    "egaStableId": "EGAS00001000455",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-04-19T22:00.000Z",
+    "studyAbstract": "Whole-blood samples of 16 mother-child pairs with differing maternal smoking behaviour were bisulfite treated and sequenced with deep coverage to identify smoking-associated differentially methylated regions.RNA-sequencing and ChIP-sequencing of 4 chromatin marks complete the data set and allow for integrative analyses, functional region annotation and to study the impact of epigenetic changes on gene expression.Longitudinal data spanning several years provides the means to investigate the stability of observed differences of all data types.",
+    "studyType": "Epigenetics",
+    "title": "Whole genome bisufite sequencing of smoking and non-smoking mother-child pairsBisufite sequencing, RNA-seq and ChIP-Seq data of whole blood samples from smoking and non-smoking mothers and their children at gestation/birth and follow-up years."
+  },
+  {
+    "alias": "ena-STUDY-NEUROMICS-06-02-2014-22:55:01:287-32",
+    "centerName": "Neuromics",
+    "creationTime": "2014-02-06T21:11.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001002695",
+      "EGAD00001002699"
+    ],
+    "description": "This study contains omics datasets from the Neuromics project (www.rd-neuromics.eu) on rare neuromuscular and neurodegenerative disorders.   Data includes BAM and VCF files from whole-exome sequencing and standardised phenotypic data mapped to the human phenotype ontology (HPO). In some cases proteomic, transcriptomic and metabolomic data may also be available.  This study groups together datasets from individuals with a Huntington's disease phenotype and also includes some unaffected family members. Search under the Neuromics name to find related studies for other neuromuscular and neurodegenerative disorders.",
+    "egaStableId": "EGAS00001000698",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2019-09-04T22:00.000Z",
+    "studyAbstract": "This study contains omics datasets from the Neuromics project (www.rd-neuromics.eu) on rare neuromuscular and neurodegenerative disorders.   Data includes BAM and VCF files from whole-exome sequencing and standardised phenotypic data mapped to the human phenotype ontology (HPO). In some cases proteomic, transcriptomic and metabolomic data may also be available.  This study groups together datasets from individuals with a Huntington's disease phenotype and also includes some unaffected family members. Search under the Neuromics name to find related studies for other neuromuscular and neurodegenerative disorders.",
+    "studyType": "Other",
+    "title": "Neuromics / RD-Connect - Huntington's disease"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-IBIOS-11-04-2014-11:44:21:184-48",
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2014-04-11T09:28.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001000963",
+      "EGAD00001000964"
+    ],
+    "description": "Schwannomatosis (MIM #162091) is characterized by the development of multiple schwannomas without vestibular nerve involvement (which is a characteristic of neurofibromatosis type 2 - NF2). In an effort to detect novel genetic alterations predisposing to schwannomatosis, we sequenced eight tumor-blood DNA pairs from de novo schwannomatosis patients. The results of our study are present in the paper \"Whole exome sequencing reveals that the majority of schwannomatosis cases remain unexplained after excluding SMARCB1 and LZTR1 germline variants\" published in Acta Neuropathologica (PMID:25008767)",
+    "egaStableId": "EGAS00001000767",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": null,
+    "studyAbstract": "Schwannomatosis (MIM #162091) is characterized by the development of multiple schwannomas without vestibular nerve involvement (which is a characteristic of neurofibromatosis type 2 - NF2). In an effort to detect novel genetic alterations predisposing to schwannomatosis, we sequenced eight tumor-blood DNA pairs from de novo schwannomatosis patients. The results of our study are present in the paper \"Whole exome sequencing reveals that the majority of schwannomatosis cases remain unexplained after excluding SMARCB1 and LZTR1 germline variants\" published in Acta Neuropathologica (PMID:25008767)",
+    "studyType": "Other",
+    "title": "Next generation sequencing of sporadic schwannomatosis samples"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-IBIOS-07-07-2014-11:44:41:912-82",
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2014-07-07T09:47.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001000884"
+    ],
+    "description": "To elucidate whether newly acquired genetic alterations during serial transplantation of patient derived primary pancreatic cancer cultures contribute to the observed clonal dynamics in vivo, all coding genes of two  patient derived primary cultures and derived genetically marked serial xenografts (1°/2°/3°) were sequenced.",
+    "egaStableId": "EGAS00001000882",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-03-28T22:00.000Z",
+    "studyAbstract": "To elucidate whether newly acquired genetic alterations during serial transplantation of patient derived primary pancreatic cancer cultures contribute to the observed clonal dynamics in vivo, all coding genes of two  patient derived primary cultures and derived genetically marked serial xenografts (1°/2°/3°) were sequenced.",
+    "studyType": "Other",
+    "title": "Succession Of Transiently Active Tumour-Initiating Cell Clones inHuman Pancreatic Cancer"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-IBIOS-28-07-2014-14:03:57:377-342",
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2014-07-28T12:08.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001000992",
+      "EGAD00001000993",
+      "EGAD00001000994",
+      "EGAD00001000995"
+    ],
+    "description": "Blastemal histology in chemotherapy-treated pediatric Wilms tumors (nephroblastoma) is associated with adverse prognosis. In order to find novel therapeutic leads for this subgroup of patients, we analyzed 58 such Wilms tumors by exome and transcriptome analysis and validated our findings in larger independent cohorts. Recurrent mutations identified either somatically or in the germline included a hotspot mutation (Q177R) in the homeodomain of SIX1 and SIX2 in tumors with high proliferative potential, mutations in microprocessor genes like DROSHA, DGCR8, DICER1 and DIS3L2, and alterations in IGF2, MYCN, and TP53, the latter being strongly associated with dismal outcome. DROSHA and DGCR8 mutations had a strong effect on miRNA profiles in tumors, which we confirmed in cell lines transfected with mutant DROSHA.",
+    "egaStableId": "EGAS00001000906",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-03-28T22:00.000Z",
+    "studyAbstract": "Blastemal histology in chemotherapy-treated pediatric Wilms tumors (nephroblastoma) is associated with adverse prognosis. In order to find novel therapeutic leads for this subgroup of patients, we analyzed 58 such Wilms tumors by exome and transcriptome analysis and validated our findings in larger independent cohorts. Recurrent mutations identified either somatically or in the germline included a hotspot mutation (Q177R) in the homeodomain of SIX1 and SIX2 in tumors with high proliferative potential, mutations in microprocessor genes like DROSHA, DGCR8, DICER1 and DIS3L2, and alterations in IGF2, MYCN, and TP53, the latter being strongly associated with dismal outcome. DROSHA and DGCR8 mutations had a strong effect on miRNA profiles in tumors, which we confirmed in cell lines transfected with mutant DROSHA.",
+    "studyType": "Other",
+    "title": "Mutations in the SIX1/2 pathway and the DROSHA/DGCR8 miRNA microprocessor complex underlie high-risk blastemal type Wilms tumors"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-IBIOS-26-08-2014-12:22:47:124-866",
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2014-08-26T10:00.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001000997",
+      "EGAD00001001384"
+    ],
+    "description": "Clinical genome and transcriptome sequencing in younger adults with advanced-stage cancer across all histologies: DKFZ-HIPO Project H021 (http://www.hipo-heidelberg.org/hipo2/index.php/menu-item-2/32-021-prospective-genetic-characterization-of-tumors-from-individual-patients-of-special-interest) / NCT MASTER (http://www.nct-heidelberg.de/forschung/nct-master.html)",
+    "egaStableId": "EGAS00001000948",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-03-28T22:00.000Z",
+    "studyAbstract": "Clinical genome and transcriptome sequencing in younger adults with advanced-stage cancer across all histologies: DKFZ-HIPO Project H021 (http://www.hipo-heidelberg.org/hipo2/index.php/menu-item-2/32-021-prospective-genetic-characterization-of-tumors-from-individual-patients-of-special-interest) / NCT MASTER (http://www.nct-heidelberg.de/forschung/nct-master.html)",
+    "studyType": "Other",
+    "title": "DKFZ-HIPO Project H021/NCT MASTER"
+  },
+  {
+    "alias": "ena-STUDY-TUSCO-27-02-2015-17:06:14:403-294",
+    "centerName": "TUSCO",
+    "creationTime": "2015-02-27T16:26.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00010001001",
+      "EGAD00010001564",
+      "EGAD00010001589"
+    ],
+    "description": "Study of primary renal cancers as well as metastases derived from renal cancers in various distant organs.",
+    "egaStableId": "EGAS00001001176",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-08-18T22:00.000Z",
+    "studyAbstract": "Study of primary renal cancers as well as metastases derived from renal cancers in various distant organs.",
+    "studyType": "Other",
+    "title": "Study of renal cancers and renal cancer metastases"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-IBIOS-20-03-2015-12:32:08:389-558",
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2015-03-20T11:23.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001001598"
+    ],
+    "description": "Despite the established role of the transcription factor MYC in cancer, little is known about the involvement of lncRNAs in mediating MYC’s function. Here we have intersected RNA-sequencing data from MYC-inducible cell lines, from a cohort of 91 mature B-cell lymphomas and from sorted germinal-center B-cells. By this approach, we identified 13 lncRNAs differentially expressed in IG-MYC-positive Burkitt lymphoma and regulated by MYC in the model cell lines. Among them we focused on a lncRNA that we named MINCR, showing a strong correlation with MYC expression in MYC-positive lymphomas and in pancreatic ductal adenocarcinomas. RNAi experiments showed that MINCR controls cellular viability by influencing the expression of MYC-regulated cell cycle genes. Finally we provide evidences that down-regulation of AURKA, AURKB and CTD1 may explain the reduction in cellular proliferation observed upon MINCR knock-down. We therefore suggest that MINCR acts as a modulator of MYC transcriptional control of cell cycle genes.",
+    "egaStableId": "EGAS00001001199",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2015-09-07T22:00.000Z",
+    "studyAbstract": "Despite the established role of the transcription factor MYC in cancer, little is known about the involvement of lncRNAs in mediating MYC’s function. Here we have intersected RNA-sequencing data from MYC-inducible cell lines, from a cohort of 91 mature B-cell lymphomas and from sorted germinal-center B-cells. By this approach, we identified 13 lncRNAs differentially expressed in IG-MYC-positive Burkitt lymphoma and regulated by MYC in the model cell lines. Among them we focused on a lncRNA that we named MINCR, showing a strong correlation with MYC expression in MYC-positive lymphomas and in pancreatic ductal adenocarcinomas. RNAi experiments showed that MINCR controls cellular viability by influencing the expression of MYC-regulated cell cycle genes. Finally we provide evidences that down-regulation of AURKA, AURKB and CTD1 may explain the reduction in cellular proliferation observed upon MINCR knock-down. We therefore suggest that MINCR acts as a modulator of MYC transcriptional control of cell cycle genes.",
+    "studyType": "Other",
+    "title": "MINCR is a MYC-induced lncRNA able to modulate MYC’s transcriptional network in Burkitt lymphoma cells"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-IBIOS-11-05-2015-14:22:15:176-132",
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2015-05-11T12:28.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001001386"
+    ],
+    "description": "Short hairpin RNA (shRNA) expression strategies that allow safe and persistent target mRNA knockdown are key to the success of many in vitro or in vivo RNAi applications. Here, we propose a novel solution which is expression of a promoterless miRNA-adapted shRNA (shmiRNA) from an engineered genomic miRNA locus. For proof-of-concept, we genetically “vaccinated” liver cells against a human pathogen, by using TALEns or CRISPR to integrate an anti-hepatitis C virus (HCV) shmiRNA into the liver-specific miR-122/hcr gene. Reporter assays and qRT-PCR confirmed anti-HCV shmiRNA expression as well as miR-122 integrity and functionality. Specificity and safety of shmiRNA integration were validated via PCR, cDNA and miRNA profiling, and whole genome sequencing. A subgenomic HCV replicon and a full-length reporter virus, but not a Dengue virus control, were significantly impaired in the modified cells. Our original combination of DNA engineering and RNAi expression technologies should benefit numerous applications, from basic miRNA research, to human cell and gene therapy.",
+    "egaStableId": "EGAS00001001252",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-07-26T22:00.000Z",
+    "studyAbstract": "Short hairpin RNA (shRNA) expression strategies that allow safe and persistent target mRNA knockdown are key to the success of many in vitro or in vivo RNAi applications. Here, we propose a novel solution which is expression of a promoterless miRNA-adapted shRNA (shmiRNA) from an engineered genomic miRNA locus. For proof-of-concept, we genetically “vaccinated” liver cells against a human pathogen, by using TALEns or CRISPR to integrate an anti-hepatitis C virus (HCV) shmiRNA into the liver-specific miR-122/hcr gene. Reporter assays and qRT-PCR confirmed anti-HCV shmiRNA expression as well as miR-122 integrity and functionality. Specificity and safety of shmiRNA integration were validated via PCR, cDNA and miRNA profiling, and whole genome sequencing. A subgenomic HCV replicon and a full-length reporter virus, but not a Dengue virus control, were significantly impaired in the modified cells. Our original combination of DNA engineering and RNAi expression technologies should benefit numerous applications, from basic miRNA research, to human cell and gene therapy.",
+    "studyType": "Other",
+    "title": "Engineering of a promoterless anti-viral RNAi hairpin into an endogenous miRNA locus"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-IBIOS-23-06-2015-07:58:29:604-312",
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2015-06-23T05:40.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001001444",
+      "EGAD00001002135",
+      "EGAD00001002136",
+      "EGAD00001002137",
+      "EGAD00001002138"
+    ],
+    "description": "Whole exome sequencing of atypical teratoid /rhabdoid tumors (AT/RTs) revealed recurrent mutations only in SMARCB1, a gene involved in chromatin remodeling. However, preliminary data from our lab using gene expression and DNA methylation arrays shows that there are three distinct molecular subgroups of AT/RTs, suggesting that other molecular alterations underlying the development of these aggressive pediatric brain tumors must be found outside the coding genome or at the epigenomic level. Identification of these (epi)genomic alterations, which we intend to address in this project, may lead to novel treatment strategies for these tumors and reveal options for meaningful patient stratification.",
+    "egaStableId": "EGAS00001001297",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-03-28T22:00.000Z",
+    "studyAbstract": "Whole exome sequencing of atypical teratoid /rhabdoid tumors (AT/RTs) revealed recurrent mutations only in SMARCB1, a gene involved in chromatin remodeling. However, preliminary data from our lab using gene expression and DNA methylation arrays shows that there are three distinct molecular subgroups of AT/RTs, suggesting that other molecular alterations underlying the development of these aggressive pediatric brain tumors must be found outside the coding genome or at the epigenomic level. Identification of these (epi)genomic alterations, which we intend to address in this project, may lead to novel treatment strategies for these tumors and reveal options for meaningful patient stratification.",
+    "studyType": "Other",
+    "title": "Comprehensive analysis of the (epi)genome of pediatric atypical teratoid/rhabdoid tumours (AT/RTs)"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-IBIOS-13-08-2015-07:31:20:378-254",
+    "centerName": "DKFZ-IBIOS",
+    "creationTime": "2015-08-13T05:29.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001001468",
+      "EGAD00001001612"
+    ],
+    "description": "We obtained miRNA profiles by miRnome sequencing from ICGC MMML-Seq patients diagnosed with Burkitt lymphoma, diffuse large B-cell lymphoma and follicular lymphoma and provide evidence of subtype-specific miRNA expression differences. We describe differentially expressed, mutated, edited and not previously annotated miRNAs.\nAddditionally, by performing argonaute-2 photoactivatable ribonucleoside-enhanced cross-linking and immunoprecipitation (PAR-CLIP) experiments, we obtained a set of biochemically-validated miRNA binding sites and  identified miRNA-mRNA interaction pairs with a negative correlation in patient RNASeq data.",
+    "egaStableId": "EGAS00001001394",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-10-12T22:00.000Z",
+    "studyAbstract": "We obtained miRNA profiles by miRnome sequencing from ICGC MMML-Seq patients diagnosed with Burkitt lymphoma, diffuse large B-cell lymphoma and follicular lymphoma and provide evidence of subtype-specific miRNA expression differences. We describe differentially expressed, mutated, edited and not previously annotated miRNAs.\nAddditionally, by performing argonaute-2 photoactivatable ribonucleoside-enhanced cross-linking and immunoprecipitation (PAR-CLIP) experiments, we obtained a set of biochemically-validated miRNA binding sites and  identified miRNA-mRNA interaction pairs with a negative correlation in patient RNASeq data.",
+    "studyType": "Other",
+    "title": "Genome-wide identification of distinct miRNA-mRNA target regulation pairs in Non-Hodgkin lymphomas: a report from the ICGC MMML-Seq consortium"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-HIPO-03-03-2016-10:10:56:379-20",
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-03-03T09:02.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001002055",
+      "EGAD00001002056",
+      "EGAD00010000947",
+      "EGAD00010000948",
+      "EGAD00010000949"
+    ],
+    "description": "As new generations of targeted therapies emerge and tumor genome sequencing discovers increasingly comprehensive mutation repertoires, the functional relationships of mutations to tumor phenotypes remain largely unknown. Here, we measured ex vivo sensitivity of 246 blood cancers to 63 drugs alongside genome, transcriptome, and DNA methylome analysis to understand determinants of drug response. We assembled a primary blood cancer cell encyclopedia data set that revealed disease-specific sensitivities for each cancer. Within chronic lymphocytic leukemia (CLL), responses to 62% of drugs were associated with 2 or more mutations, and linked the B cell receptor (BCR) pathway to trisomy 12, an important driver of CLL. Based on drug responses, the disease could be organized into phenotypic subgroups characterized by exploitable dependencies on BCR, mTOR, or MEK signaling and associated with mutations, gene expression, and DNA methylation. Fourteen percent of CLLs were driven by mTOR signaling in a non–BCR-dependent manner. Multivariate modeling revealed immunoglobulin heavy chain variable gene (IGHV) mutation status and trisomy 12 as the most important modulators of response to kinase inhibitors in CLL. Ex vivo drug responses were associated with outcome. This study overcomes the perception that most mutations do not influence drug response of cancer, and points to an updated approach to understanding tumor biology, with implications for biomarker discovery and cancer care.",
+    "egaStableId": "EGAS00001001746",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-04-28T22:00.000Z",
+    "studyAbstract": "As new generations of targeted therapies emerge and tumor genome sequencing discovers increasingly comprehensive mutation repertoires, the functional relationships of mutations to tumor phenotypes remain largely unknown. Here, we measured ex vivo sensitivity of 246 blood cancers to 63 drugs alongside genome, transcriptome, and DNA methylome analysis to understand determinants of drug response. We assembled a primary blood cancer cell encyclopedia data set that revealed disease-specific sensitivities for each cancer. Within chronic lymphocytic leukemia (CLL), responses to 62% of drugs were associated with 2 or more mutations, and linked the B cell receptor (BCR) pathway to trisomy 12, an important driver of CLL. Based on drug responses, the disease could be organized into phenotypic subgroups characterized by exploitable dependencies on BCR, mTOR, or MEK signaling and associated with mutations, gene expression, and DNA methylation. Fourteen percent of CLLs were driven by mTOR signaling in a non–BCR-dependent manner. Multivariate modeling revealed immunoglobulin heavy chain variable gene (IGHV) mutation status and trisomy 12 as the most important modulators of response to kinase inhibitors in CLL. Ex vivo drug responses were associated with outcome. This study overcomes the perception that most mutations do not influence drug response of cancer, and points to an updated approach to understanding tumor biology, with implications for biomarker discovery and cancer care.",
+    "studyType": "Other",
+    "title": "Drug-perturbation-based stratification of blood cancer"
+  },
+  {
+    "alias": "ena-STUDY-MUO-19-04-2016-11:18:19:401-62",
+    "centerName": "MUO",
+    "creationTime": "2016-04-19T13:21.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001002067"
+    ],
+    "description": "Renal cell carcinoma (RCC) is a genomically heterogeneous tumor. In the present project, the question whether intratumoral heterogeneity follows a zonal pattern indicating spatial niches was addressed. Whole exome sequencing of 16 paired samples from tumor periphery and center revealed a number of region-specific functional SNVs and Indels. Therefore, RCCs are not composed of evenly admixed tumor cells but show topological differences in their clonal composition.",
+    "egaStableId": "EGAS00001001784",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-08-22T22:00.000Z",
+    "studyAbstract": "Renal cell carcinoma (RCC) is a genomically heterogeneous tumor. In the present project, the question whether intratumoral heterogeneity follows a zonal pattern indicating spatial niches was addressed. Whole exome sequencing of 16 paired samples from tumor periphery and center revealed a number of region-specific functional SNVs and Indels. Therefore, RCCs are not composed of evenly admixed tumor cells but show topological differences in their clonal composition.",
+    "studyType": "Other",
+    "title": "Analysis of tumor periphery and center-specific mutations in renal cell carcinoma"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-HIPO-23-05-2016-08:10:16:493-7",
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-05-23T13:19.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001002159"
+    ],
+    "description": "Purpose: Altered FGFR1 signaling has emerged as therapeutic target in various epithelial malignancies. In contrast, the role of FGFR1 in soft-tissue sarcoma (STS) has not been established. Prompted by the detection and subsequent therapeutic inhibition of amplified FGFR1 in a patient with metastatic leiomyosarcoma, we investigated the oncogenic properties and potential as drug target of FGFR1 in STS.Experimental Design: The frequency of FGFR1 amplification and overexpression, as assessed by fluorescence in situ hybridization, microarray-based comparative genomic hybridization and mRNA expression profiling, SNP array profiling, and RNA sequencing, was determined in three independent patient cohorts. The sensitivity of STS cell lines with or without FGFR1 alterations to genetic and pharmacologic FGFR1 inhibition and the signaling pathways engaged by FGFR1 were investigated using short-term viability assays, long-term colony formation assays, and biochemical analysis.Results: Increased FGFR1 copy number was detected in 74 of 190 (38.9%; Cohort 1), 13 of 79 (16.5%; Cohort 2), and 80 of 254 (31.5%; Cohort 3) patients. FGFR1 overexpression occurred in 16 of 79 (20.2%, Cohort 2) and 39 of 254 (15.4%; Cohort 3) patients. Targeting of FGFR1 by short hairpin RNA-mediated knockdown and different small-molecule inhibitors (PD173074, AZD4547, BGJ398) revealed that the requirement for FGFR1 signaling in STS cells is primarily dictated by FGFR1 expression levels, and identified the MAPK-ERK1/2 axis as critical FGFR1 effector pathway.Conclusion: These data identify FGFR1 as driver gene in multiple STS subtypes and support FGFR1 inhibition, guided by patient selection according to FGFR1 expression and monitoring of MAPK-ERK1/2 signaling, as therapeutic option in this challenging group of diseases.H021",
+    "egaStableId": "EGAS00001001844",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-07-10T22:00.000Z",
+    "studyAbstract": "Purpose: Altered FGFR1 signaling has emerged as therapeutic target in various epithelial malignancies. In contrast, the role of FGFR1 in soft-tissue sarcoma (STS) has not been established. Prompted by the detection and subsequent therapeutic inhibition of amplified FGFR1 in a patient with metastatic leiomyosarcoma, we investigated the oncogenic properties and potential as drug target of FGFR1 in STS.Experimental Design: The frequency of FGFR1 amplification and overexpression, as assessed by fluorescence in situ hybridization, microarray-based comparative genomic hybridization and mRNA expression profiling, SNP array profiling, and RNA sequencing, was determined in three independent patient cohorts. The sensitivity of STS cell lines with or without FGFR1 alterations to genetic and pharmacologic FGFR1 inhibition and the signaling pathways engaged by FGFR1 were investigated using short-term viability assays, long-term colony formation assays, and biochemical analysis.Results: Increased FGFR1 copy number was detected in 74 of 190 (38.9%; Cohort 1), 13 of 79 (16.5%; Cohort 2), and 80 of 254 (31.5%; Cohort 3) patients. FGFR1 overexpression occurred in 16 of 79 (20.2%, Cohort 2) and 39 of 254 (15.4%; Cohort 3) patients. Targeting of FGFR1 by short hairpin RNA-mediated knockdown and different small-molecule inhibitors (PD173074, AZD4547, BGJ398) revealed that the requirement for FGFR1 signaling in STS cells is primarily dictated by FGFR1 expression levels, and identified the MAPK-ERK1/2 axis as critical FGFR1 effector pathway.Conclusion: These data identify FGFR1 as driver gene in multiple STS subtypes and support FGFR1 inhibition, guided by patient selection according to FGFR1 expression and monitoring of MAPK-ERK1/2 signaling, as therapeutic option in this challenging group of diseases.H021",
+    "studyType": "Other",
+    "title": "Targeting FGFR1 for treatment of soft-tissue sarcoma (H021)"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-HIPO-23-05-2016-09:30:27:839-9",
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-05-23T13:19.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001002160",
+      "EGAD00001002161"
+    ],
+    "description": "Sinonasal carcinomas (SNCs) comprise various rare tumor types that are characterized by marked histologic diversity and largely unknown molecular profiles, yet share an overall poor prognosis owing to an aggressive clinical course and frequent late-stage diagnosis. The lack of effective systemic therapies for locally advanced or metastatic SNC poses a major challenge to therapeutic decision making for individual patients. Here, we used whole-exome and transcriptome sequencing to identify a KIT exon 11 mutation (c.1733_1735del, p.578_579del) as actionable target in a patient with metastatic SNC whose tumor, despite all diagnostic efforts, could not be assigned to any known SNC category and was refractory to multimodal therapy. Molecularly guided treatment with imatinib resulted in a dramatic and durable response with remission of nearly all tumor manifestations, indicating a dominant driver function of mutant KIT in this tumor. This observation highlights the potential of unbiased genomic profiling for uncovering the vulnerabilities of individual malignancies, particularly in rare and unclassifiable tumors, and underscores that KIT exon 11 mutations represent tractable therapeutic targets across different histologies.H021",
+    "egaStableId": "EGAS00001001845",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-07-10T22:00.000Z",
+    "studyAbstract": "Sinonasal carcinomas (SNCs) comprise various rare tumor types that are characterized by marked histologic diversity and largely unknown molecular profiles, yet share an overall poor prognosis owing to an aggressive clinical course and frequent late-stage diagnosis. The lack of effective systemic therapies for locally advanced or metastatic SNC poses a major challenge to therapeutic decision making for individual patients. Here, we used whole-exome and transcriptome sequencing to identify a KIT exon 11 mutation (c.1733_1735del, p.578_579del) as actionable target in a patient with metastatic SNC whose tumor, despite all diagnostic efforts, could not be assigned to any known SNC category and was refractory to multimodal therapy. Molecularly guided treatment with imatinib resulted in a dramatic and durable response with remission of nearly all tumor manifestations, indicating a dominant driver function of mutant KIT in this tumor. This observation highlights the potential of unbiased genomic profiling for uncovering the vulnerabilities of individual malignancies, particularly in rare and unclassifiable tumors, and underscores that KIT exon 11 mutations represent tractable therapeutic targets across different histologies.H021",
+    "studyType": "Other",
+    "title": "Mutant KIT as imatinib-sensitive target in metastatic sinonasal carcinoma (H021)"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-HIPO-23-05-2016-09:36:42:065-13",
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-05-23T13:19.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001002162",
+      "EGAD00001002163"
+    ],
+    "description": "Identification of the tissue of origin in cancer of unknown primary (CUP) poses a diagnostic challenge and is critical for directing site-specific therapy. Currently, clinical decision making in patients with CUP primarily relies on histopathology and clinical features. Comprehensive molecular profiling has the potential to contribute to diagnostic categorization and, most importantly, guide CUP therapy through identification of actionable lesions. We here report the case of an advanced-stage malignancy initially mimicking poorly differentiated soft-tissue sarcoma that did not respond to multi-agent chemotherapy. Molecular profiling within a clinical whole-exome and transcriptome sequencing program revealed a heterozygous, highly amplified KRAS G12S mutation, compound-heterozygous TP53 mutation/deletion, high mutational load, and focal amplification of chromosomes 9p (including PDL1 [CD274] and JAK2) and 10p (including GATA3). Integrated analysis of molecular data and conventional histopathology suggested a diagnosis of triple-negative breast cancer (TNBC) and provided a rationale for immune checkpoint inhibitor therapy with pembrolizumab, which resulted in rapid clinical improvement and a lasting partial remission. Analysis of 157 TNBC samples from The Cancer Genome Atlas revealed focal, high-level PDL1 amplification coinciding with excessive PDL1 mRNA expression in 24% of cases. Collectively, these results illustrate the diagnostic utility of multidimensional tumor profiling in cases with non-descript histology and immune phenotype, demonstrate the predictive power of genomic PDL1 amplification for immune checkpoint inhibition, and suggest a targeted therapeutic strategy in chromosome 9p24.1/PDL1-amplified cancers.H021",
+    "egaStableId": "EGAS00001001846",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-07-10T22:00.000Z",
+    "studyAbstract": "Identification of the tissue of origin in cancer of unknown primary (CUP) poses a diagnostic challenge and is critical for directing site-specific therapy. Currently, clinical decision making in patients with CUP primarily relies on histopathology and clinical features. Comprehensive molecular profiling has the potential to contribute to diagnostic categorization and, most importantly, guide CUP therapy through identification of actionable lesions. We here report the case of an advanced-stage malignancy initially mimicking poorly differentiated soft-tissue sarcoma that did not respond to multi-agent chemotherapy. Molecular profiling within a clinical whole-exome and transcriptome sequencing program revealed a heterozygous, highly amplified KRAS G12S mutation, compound-heterozygous TP53 mutation/deletion, high mutational load, and focal amplification of chromosomes 9p (including PDL1 [CD274] and JAK2) and 10p (including GATA3). Integrated analysis of molecular data and conventional histopathology suggested a diagnosis of triple-negative breast cancer (TNBC) and provided a rationale for immune checkpoint inhibitor therapy with pembrolizumab, which resulted in rapid clinical improvement and a lasting partial remission. Analysis of 157 TNBC samples from The Cancer Genome Atlas revealed focal, high-level PDL1 amplification coinciding with excessive PDL1 mRNA expression in 24% of cases. Collectively, these results illustrate the diagnostic utility of multidimensional tumor profiling in cases with non-descript histology and immune phenotype, demonstrate the predictive power of genomic PDL1 amplification for immune checkpoint inhibition, and suggest a targeted therapeutic strategy in chromosome 9p24.1/PDL1-amplified cancers.H021",
+    "studyType": "Other",
+    "title": "Integration of genomics and histology reveals diagnosis and effective therapy of refractory cancer of unknown primary with PDL1 amplification (H021)"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-HIPO-23-05-2016-20:08:44:897-46",
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-05-23T18:49.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001002164"
+    ],
+    "description": "Here we report the case of an acute promyelocytic leukemia (APL) patient who, though negative for FLT3 mutations at diagnosis, developed isolated FLT3-TKD positive meningeal relapse, which, in retrospect, could be traced back to a minute bone marrow subclone present at first diagnosis. Initially, the 48-year old female diagnosed with high-risk APL had achieved complete molecular remission after standard treatment with all-trans retinoic acid (ATRA) and chemotherapy according to the AIDA protocol. 13 months after start of ATRA maintenance the patient suffered clinically overt meningeal relapse along with minute molecular traces of PML/RARA in the bone marrow. Following treatment with arsenic trioxide (ATO) and ATRA in combination with intrathecal cytarabine and methotrexate, the patient achieved a complete molecular remission in both cerebrospinal fluid (CSF) and bone marrow, which currently lasts for two years after completion of therapy. Whole exome sequencing and subsequent ultradeep targeted re-sequencing revealed a heterozygous FLT3-TKD mutation in CSF leukemic cells (p.D835Y, c.2503G&gt;T, 1000/1961 reads (51%)), which was undetectable in the concurrent bone marrow sample. Interestingly, the FLT3-TKD mutated meningeal clone originated from a small bone marrow subclone present in a variant allele frequency of 0.4% (6/1553 reads) at initial diagnosis. This case highlights the concept of clonal evolution with a subclone harboring an additional mutation being selected as the “fittest” and leading to meningeal relapse. It also further supports earlier suggestions that FLT3 mutations may play a role for migration and clonal expansion in the CSF sanctuary site.H021",
+    "egaStableId": "EGAS00001001848",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-07-10T22:00.000Z",
+    "studyAbstract": "Here we report the case of an acute promyelocytic leukemia (APL) patient who, though negative for FLT3 mutations at diagnosis, developed isolated FLT3-TKD positive meningeal relapse, which, in retrospect, could be traced back to a minute bone marrow subclone present at first diagnosis. Initially, the 48-year old female diagnosed with high-risk APL had achieved complete molecular remission after standard treatment with all-trans retinoic acid (ATRA) and chemotherapy according to the AIDA protocol. 13 months after start of ATRA maintenance the patient suffered clinically overt meningeal relapse along with minute molecular traces of PML/RARA in the bone marrow. Following treatment with arsenic trioxide (ATO) and ATRA in combination with intrathecal cytarabine and methotrexate, the patient achieved a complete molecular remission in both cerebrospinal fluid (CSF) and bone marrow, which currently lasts for two years after completion of therapy. Whole exome sequencing and subsequent ultradeep targeted re-sequencing revealed a heterozygous FLT3-TKD mutation in CSF leukemic cells (p.D835Y, c.2503G&gt;T, 1000/1961 reads (51%)), which was undetectable in the concurrent bone marrow sample. Interestingly, the FLT3-TKD mutated meningeal clone originated from a small bone marrow subclone present in a variant allele frequency of 0.4% (6/1553 reads) at initial diagnosis. This case highlights the concept of clonal evolution with a subclone harboring an additional mutation being selected as the “fittest” and leading to meningeal relapse. It also further supports earlier suggestions that FLT3 mutations may play a role for migration and clonal expansion in the CSF sanctuary site.H021",
+    "studyType": "Other",
+    "title": "Evolution of a FLT3-TKD mutated subclone at meningeal relapse in acute promyelocytic leukemia (H021)"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-HIPO-29-05-2016-17:53:27:428-42",
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-05-29T21:55.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001002528"
+    ],
+    "description": "A subset of tumor-initiating cells (TIC) drives colorectal cancer (CRC) progression in serial mouse xenografts. The TIC compartment itself is heterogeneous and comprises hierarchically organized long-term TIC, tumor transient amplifying cells, and delayed contributing TIC. To address the genomic heterogeneity of the CRC TIC compartment, genome-wide high-coverage whole genome sequencing was performed on patient tumors (n=3), corresponding serially passaged TIC-enriched spheres, and serial xenografts.HIPO P002",
+    "egaStableId": "EGAS00001001857",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2016-09-15T22:00.000Z",
+    "studyAbstract": "A subset of tumor-initiating cells (TIC) drives colorectal cancer (CRC) progression in serial mouse xenografts. The TIC compartment itself is heterogeneous and comprises hierarchically organized long-term TIC, tumor transient amplifying cells, and delayed contributing TIC. To address the genomic heterogeneity of the CRC TIC compartment, genome-wide high-coverage whole genome sequencing was performed on patient tumors (n=3), corresponding serially passaged TIC-enriched spheres, and serial xenografts.HIPO P002",
+    "studyType": "Other",
+    "title": "Genetic subclone heterogeneity of tumor-initiating cells in human colorectal cancer"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-HIPO-01-06-2016-10:11:00:057-50",
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2016-06-01T08:03.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001002166"
+    ],
+    "description": "Background:Acquired resistance to targeted drugs is largely due to intra-tumor molecular heterogeneity and clonal selection. Objective:The objective of this study was to determine molecular alterations and mediating resistant mechanisms and to suggest additional treatment options.Design, Setting, and Participants:Four patients were enrolled into the MORE (Molecular Renal Cancer Evolution) trial. We investigated the mutational spectra of metastatic clear cell renal cell carcinoma (ccRCC) at baseline and compared them to those upon clonal evolution at progression on systemic therapy with tyrosine kinase inhibitors.Outcome Measurements:DNA was isolated from tumor tissues after surgery, metastasis biopsies after progression on sunitinib or axitinib, and subjected to whole-exome sequencing (WES). In addition, the exomes of circulating tumor DNA (ctDNA) from two patients were sequenced at baseline and at progression.Results and Limitations:Our data provide evidence for clonal evolution and various acquired resistance mechanisms of ccRCC with subclonal mutations in FLT4, MTOR, ITGA3/5, SETD2, and VHL on metastatic progression. The limited number of shared mutations in tissue and plasma biopsies indicates that both sources provide complementary information, possibly due to mutations present in metastatic lesions which were not amenable to tissue sampling but are represented in the ctDNA. Conclusion:Acquired resistance to targeted therapies in metastatic ccRCC is due to intra-tumor heterogeneity and clonal evolution. Larger patient cohorts have to be studied to estimate the benefit of WES from biopsies and ctDNA for therapy decision in metastatic ccRCC.Patient Summary:We analyzed the molecular profiles of ccRCC patients in primary tissues and metastatic tissues upon progression on tyrosine kinase inhibitor therapy. Clinically relevant mutations upon progression were detected in the metastatic sites of all of four patients, suggesting that it might be possible to derive therapies based on sequencing the metastases.?HIPO-045",
+    "egaStableId": "EGAS00001001861",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2019-01-17T23:00.000Z",
+    "studyAbstract": "Background:Acquired resistance to targeted drugs is largely due to intra-tumor molecular heterogeneity and clonal selection. Objective:The objective of this study was to determine molecular alterations and mediating resistant mechanisms and to suggest additional treatment options.Design, Setting, and Participants:Four patients were enrolled into the MORE (Molecular Renal Cancer Evolution) trial. We investigated the mutational spectra of metastatic clear cell renal cell carcinoma (ccRCC) at baseline and compared them to those upon clonal evolution at progression on systemic therapy with tyrosine kinase inhibitors.Outcome Measurements:DNA was isolated from tumor tissues after surgery, metastasis biopsies after progression on sunitinib or axitinib, and subjected to whole-exome sequencing (WES). In addition, the exomes of circulating tumor DNA (ctDNA) from two patients were sequenced at baseline and at progression.Results and Limitations:Our data provide evidence for clonal evolution and various acquired resistance mechanisms of ccRCC with subclonal mutations in FLT4, MTOR, ITGA3/5, SETD2, and VHL on metastatic progression. The limited number of shared mutations in tissue and plasma biopsies indicates that both sources provide complementary information, possibly due to mutations present in metastatic lesions which were not amenable to tissue sampling but are represented in the ctDNA. Conclusion:Acquired resistance to targeted therapies in metastatic ccRCC is due to intra-tumor heterogeneity and clonal evolution. Larger patient cohorts have to be studied to estimate the benefit of WES from biopsies and ctDNA for therapy decision in metastatic ccRCC.Patient Summary:We analyzed the molecular profiles of ccRCC patients in primary tissues and metastatic tissues upon progression on tyrosine kinase inhibitor therapy. Clinically relevant mutations upon progression were detected in the metastatic sites of all of four patients, suggesting that it might be possible to derive therapies based on sequencing the metastases.?HIPO-045",
+    "studyType": "Other",
+    "title": "Molecular evolution of metastatic clear cell renal cell carcinoma progressing under tyrosine kinase inhibitor therapy (HIPO-045)"
+  },
+  {
+    "alias": "ena-STUDY-MUO-01-09-2016-16:00:34:342-90",
+    "centerName": "MUO",
+    "creationTime": "2016-09-01T14:47.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001004887"
+    ],
+    "description": "Renal cell carcinoma with venous tumor thrombus opens the unique opportunity to investigate the clonal evolution of a tumor in two fundamentally different compartments i.e., within the confinement of an organ and inside a large blood vessel. We performed multiregion whole exome sequencing of a total of 37 samples from five consecutive patients (normal tissue, n=5; primary tumors, n=16; tumor thrombi, n=16) to &gt;35-fold target coverage. Four patients had a clear cell RCC, one patient had a poorly differentiated type II papillary RCC (RCC-VTT-04). The latter patient had a friable thrombus, the others were of solid consistency.",
+    "egaStableId": "EGAS00001001950",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2019-04-10T22:00.000Z",
+    "studyAbstract": "Renal cell carcinoma with venous tumor thrombus opens the unique opportunity to investigate the clonal evolution of a tumor in two fundamentally different compartments i.e., within the confinement of an organ and inside a large blood vessel. We performed multiregion whole exome sequencing of a total of 37 samples from five consecutive patients (normal tissue, n=5; primary tumors, n=16; tumor thrombi, n=16) to &gt;35-fold target coverage. Four patients had a clear cell RCC, one patient had a poorly differentiated type II papillary RCC (RCC-VTT-04). The latter patient had a friable thrombus, the others were of solid consistency.",
+    "studyType": "Other",
+    "title": "Mutational landscape of renal cell carcinoma with venous tumor thrombus"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-07-02-2017-08:33:32:775-288",
+    "centerName": "DKFZ",
+    "creationTime": "2017-02-07T07:39.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001003429",
+      "EGAD00001003430",
+      "EGAD00001003436",
+      "EGAD00001003437",
+      "EGAD00001003438",
+      "EGAD00001003439",
+      "EGAD00001003440"
+    ],
+    "description": "Recent developments in sequencing technologies led to the discovery of a novel form of genomic instability, termed chromothripsis. This catastrophic genomic event, involved in tumorigenesis, is characterized by tens to hundreds of simultaneously acquired locally clustered rearrangements on one chromosome. We hypothesized that leukemias developing in individuals with Ataxia Telangiectasia, who are born with two mutated copies of the ATM gene, an essential guardian of genome stability, would show a higher prevalence of chromothripsis due to the associated defect in DNA double-strand break repair. Using whole-genome sequencing, fluorescence in situ hybridization and RNA sequencing, we characterized the genomic landscape of Acute Lymphoblastic Leukemia (ALL) arising in patients with Ataxia Telangiectasia. We detected a high frequency of chromothriptic events in these tumors, specifically on acrocentric chromosomes, as compared to tumors from individuals with other types of DNA repair syndromes (27 cases total, 10 with Ataxia Telangiectasia). Our data suggest that the genomic landscape of Ataxia Telangiectasia ALL is clearly distinct from that of sporadic ALL. Mechanistically, short telomeres and compromised DNA damage response in cells of Ataxia Telangiectasia patients may be linked with frequent chromothripsis. Furthermore, we show that ATM loss is associated with increased chromothripsis prevalence in additional tumor entities.",
+    "egaStableId": "EGAS00001002270",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2017-08-29T22:00.000Z",
+    "studyAbstract": "Recent developments in sequencing technologies led to the discovery of a novel form of genomic instability, termed chromothripsis. This catastrophic genomic event, involved in tumorigenesis, is characterized by tens to hundreds of simultaneously acquired locally clustered rearrangements on one chromosome. We hypothesized that leukemias developing in individuals with Ataxia Telangiectasia, who are born with two mutated copies of the ATM gene, an essential guardian of genome stability, would show a higher prevalence of chromothripsis due to the associated defect in DNA double-strand break repair. Using whole-genome sequencing, fluorescence in situ hybridization and RNA sequencing, we characterized the genomic landscape of Acute Lymphoblastic Leukemia (ALL) arising in patients with Ataxia Telangiectasia. We detected a high frequency of chromothriptic events in these tumors, specifically on acrocentric chromosomes, as compared to tumors from individuals with other types of DNA repair syndromes (27 cases total, 10 with Ataxia Telangiectasia). Our data suggest that the genomic landscape of Ataxia Telangiectasia ALL is clearly distinct from that of sporadic ALL. Mechanistically, short telomeres and compromised DNA damage response in cells of Ataxia Telangiectasia patients may be linked with frequent chromothripsis. Furthermore, we show that ATM loss is associated with increased chromothripsis prevalence in additional tumor entities.",
+    "studyType": "Other",
+    "title": "Genomic profiling of Acute Lymphoblastic Leukemia in Ataxia Telangiectasia patients reveals tight link between ATM mutations and chromothripsis"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-15-03-2017-12:45:09:431-148",
+    "centerName": "DKFZ",
+    "creationTime": "2017-03-15T11:18.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001003230"
+    ],
+    "description": "In chronic lymphocytic leukemia (CLL), monocytes and macrophages are skewed toward protumorigenic phenotypes, including the release of tumor-supportive cytokines and the expression of immunosuppressive molecules such as programmed cell death 1 ligand 1 (PD-L1). To understand the mechanism driving protumorigenic skewing in CLL, we evaluated the role of tumor cell–derived exosomes in the cross-talk with monocytes. We carried out RNA sequencing and proteome analyses of CLL-derived exosomes and identified noncoding Y RNA hY4 as a highly abundant RNA species that is enriched in exosomes from plasma of CLL patients compared with healthy donor samples. Transfer of CLL-derived exosomes or hY4 alone to monocytes resulted in key CLL-associated phenotypes, including the release of cytokines, such as C-C motif chemokine ligand 2 (CCL2), CCL4, and interleukin-6, and the expression of PD-L1. These responses were abolished in Toll-like receptor 7 (TLR7)–deficient monocytes, suggesting exosomal hY4 as a driver of TLR7 signaling. Pharmacologic inhibition of endosomal TLR signaling resulted in a substantially reduced activation of monocytes in vitro and attenuated CLL development in vivo. Our results indicate that exosome-mediated transfer of noncoding RNAs to monocytes contributes to cancer-related inflammation and concurrent immune escape via PD-L1 expression.",
+    "egaStableId": "EGAS00001002377",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2017-07-17T22:00.000Z",
+    "studyAbstract": "In chronic lymphocytic leukemia (CLL), monocytes and macrophages are skewed toward protumorigenic phenotypes, including the release of tumor-supportive cytokines and the expression of immunosuppressive molecules such as programmed cell death 1 ligand 1 (PD-L1). To understand the mechanism driving protumorigenic skewing in CLL, we evaluated the role of tumor cell–derived exosomes in the cross-talk with monocytes. We carried out RNA sequencing and proteome analyses of CLL-derived exosomes and identified noncoding Y RNA hY4 as a highly abundant RNA species that is enriched in exosomes from plasma of CLL patients compared with healthy donor samples. Transfer of CLL-derived exosomes or hY4 alone to monocytes resulted in key CLL-associated phenotypes, including the release of cytokines, such as C-C motif chemokine ligand 2 (CCL2), CCL4, and interleukin-6, and the expression of PD-L1. These responses were abolished in Toll-like receptor 7 (TLR7)–deficient monocytes, suggesting exosomal hY4 as a driver of TLR7 signaling. Pharmacologic inhibition of endosomal TLR signaling resulted in a substantially reduced activation of monocytes in vitro and attenuated CLL development in vivo. Our results indicate that exosome-mediated transfer of noncoding RNAs to monocytes contributes to cancer-related inflammation and concurrent immune escape via PD-L1 expression.",
+    "studyType": "Other",
+    "title": "Tumor-derived exosomes modulate PD-L1 expression in monocytes"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-HIPO-25-04-2017-17:13:07:370-329",
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2017-04-25T15:12.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001003827",
+      "EGAD00001003828",
+      "EGAD00001003829"
+    ],
+    "description": "Leiomyosarcoma (LMS) is an aggressive mesenchmyal malignancy with few therapeutic options. The mechanisms underlying LMS development, including clinically actionable genetic vulnerabilities, are largely unknown. We performed genomic and transcriptomic profiling of a large cohort of LMS tumors and identified substantial mutational heterogeneity, near-universal inactivation of TP53 and RB1, widespread DNA copy number alterations, chromothripsis, and frequent whole-genome duplication. Furthermore, we discovered recurrent alterations in telomere maintenance genes such as ATRX, RBL2, and RPA1, resulting in alternative lengthening of telomeres in 78% of cases. Finally, most tumors displayed hallmarks of “BRCAness”, including alterations in various homologous recombination DNA repair genes, multiple structural rearrangements, and enrichment of specific mutational signatures, and cultured LMS cells were sensitive towards olaparib and cisplatin treatment. This first comprehensive study of genetic alterations in LMS has uncovered key biological features that may inform future experimental research and enable the design of novel therapeutic strategies for this disease.",
+    "egaStableId": "EGAS00001002437",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2017-12-12T23:00.000Z",
+    "studyAbstract": "Leiomyosarcoma (LMS) is an aggressive mesenchmyal malignancy with few therapeutic options. The mechanisms underlying LMS development, including clinically actionable genetic vulnerabilities, are largely unknown. We performed genomic and transcriptomic profiling of a large cohort of LMS tumors and identified substantial mutational heterogeneity, near-universal inactivation of TP53 and RB1, widespread DNA copy number alterations, chromothripsis, and frequent whole-genome duplication. Furthermore, we discovered recurrent alterations in telomere maintenance genes such as ATRX, RBL2, and RPA1, resulting in alternative lengthening of telomeres in 78% of cases. Finally, most tumors displayed hallmarks of “BRCAness”, including alterations in various homologous recombination DNA repair genes, multiple structural rearrangements, and enrichment of specific mutational signatures, and cultured LMS cells were sensitive towards olaparib and cisplatin treatment. This first comprehensive study of genetic alterations in LMS has uncovered key biological features that may inform future experimental research and enable the design of novel therapeutic strategies for this disease.",
+    "studyType": "Other",
+    "title": "Integrative genomic and transcriptomic analysis of adult leiomyosarcoma (HIPO-028, HIPO-018, HIPO-021)"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-HIPO-26-04-2017-14:27:01:528-7",
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2017-04-26T12:06.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001003325"
+    ],
+    "description": "Cancers acquire multiple somatic mutations that can lead to the generation of immunogenic mutation-induced neoantigens. These neoantigens can be recognized by the host’s immune system. However, continuous stimulation of immune cells against tumor antigens can lead to immune cell exhaustion, which allows uncontrolled outgrowth of tumor cells. Recently, immune checkpoint inhibitors have emerged as a novel approach to overcome immune cell exhaustion and re-activate anti-tumor immune responses. In particular, antibodies blocking the exhaustion-mediating programmed death receptor (PD-1)/PD-L1 pathway have shown clinical efficacy. The effects were particularly pronounced in tumors with DNA mismatch repair deficiency and a high mutational load, which typically occur in the colon and  endometrium. Here, we report on a 24-year old woman diagnosed with extrahepatic cholangiocarcinoma who showed strong and durable response to the immune checkpoint inhibitor pembrolizumab, although treatment was initiated at an advanced stage of disease. The patient’s tumor displayed DNA mismatch repair deficiency and microsatellite instability (MSI), but lacked other features commonly discussed as predictors of response towards checkpoint blockade, such as PD-L1 expression or dense infiltration with cytotoxic T cells. Notably, high levels of HLA class I and II antigen expression were detected in the tumor, suggesting a potential causal relation between functionality of the tumor’s antigen presentation machinery and the success of immune checkpoint blockade. We suggest determining MSI status in combination with HLA class I and II antigen expression in tumors potentially eligible for immune checkpoint blockade even in the absence of conventional markers predictive for anti-PD-1/PD-L1 therapy and in entities not commonly linked to MSI phenotype. Further studies are required to determine the value of these markers for predicting the success of immune checkpoint blockade.  (H021)",
+    "egaStableId": "EGAS00001002441",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-05-01T22:00.000Z",
+    "studyAbstract": "Cancers acquire multiple somatic mutations that can lead to the generation of immunogenic mutation-induced neoantigens. These neoantigens can be recognized by the host’s immune system. However, continuous stimulation of immune cells against tumor antigens can lead to immune cell exhaustion, which allows uncontrolled outgrowth of tumor cells. Recently, immune checkpoint inhibitors have emerged as a novel approach to overcome immune cell exhaustion and re-activate anti-tumor immune responses. In particular, antibodies blocking the exhaustion-mediating programmed death receptor (PD-1)/PD-L1 pathway have shown clinical efficacy. The effects were particularly pronounced in tumors with DNA mismatch repair deficiency and a high mutational load, which typically occur in the colon and  endometrium. Here, we report on a 24-year old woman diagnosed with extrahepatic cholangiocarcinoma who showed strong and durable response to the immune checkpoint inhibitor pembrolizumab, although treatment was initiated at an advanced stage of disease. The patient’s tumor displayed DNA mismatch repair deficiency and microsatellite instability (MSI), but lacked other features commonly discussed as predictors of response towards checkpoint blockade, such as PD-L1 expression or dense infiltration with cytotoxic T cells. Notably, high levels of HLA class I and II antigen expression were detected in the tumor, suggesting a potential causal relation between functionality of the tumor’s antigen presentation machinery and the success of immune checkpoint blockade. We suggest determining MSI status in combination with HLA class I and II antigen expression in tumors potentially eligible for immune checkpoint blockade even in the absence of conventional markers predictive for anti-PD-1/PD-L1 therapy and in entities not commonly linked to MSI phenotype. Further studies are required to determine the value of these markers for predicting the success of immune checkpoint blockade.  (H021)",
+    "studyType": "Other",
+    "title": "Successful immune checkpoint blockade in a patient with advanced stage microsatellite unstable biliary tract cancer (H021)"
+  },
+  {
+    "alias": "ena-STUDY-dkfz_b062-27-06-2017-13:10:10:718-409",
+    "centerName": "dkfz_b062",
+    "creationTime": "2017-06-27T11:12.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001003544",
+      "EGAD00001003545",
+      "EGAD00001003573"
+    ],
+    "description": "Brain tumors are the leading cause of cancer-related death in children. Genomic studies have provided insights into molecular\nsubgroups and oncogenic drivers of pediatric brain tumors that may lead to novel therapeutic strategies. To evaluate new\ntreatments, better preclinical models adequately reflecting the biological heterogeneity are needed. Through the Children’s Oncology Group ACNS02B3 study, we have generated and comprehensively characterized 30 patient-derived orthotopic\nxenograft models and 7 cell lines representing 14 molecular subgroups of pediatric brain tumors. Patient-derived orthotopic\nxenograft models were found to be representative of the human tumors they were derived from in terms of histology, immunohistochemistry, gene expression, DNA methylation, copy number, and mutational profiles. In vivo drug sensitivity of targeted therapeutics was associated with distinct molecular tumor subgroups and specific genetic alterations. These models and their molecular characterization provide an unprecedented resource for the cancer community to study key oncogenic drivers and to evaluate novel treatment strategies.",
+    "egaStableId": "EGAS00001002536",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-10-19T22:00.000Z",
+    "studyAbstract": "Brain tumors are the leading cause of cancer-related death in children. Genomic studies have provided insights into molecular\nsubgroups and oncogenic drivers of pediatric brain tumors that may lead to novel therapeutic strategies. To evaluate new\ntreatments, better preclinical models adequately reflecting the biological heterogeneity are needed. Through the Children’s Oncology Group ACNS02B3 study, we have generated and comprehensively characterized 30 patient-derived orthotopic\nxenograft models and 7 cell lines representing 14 molecular subgroups of pediatric brain tumors. Patient-derived orthotopic\nxenograft models were found to be representative of the human tumors they were derived from in terms of histology, immunohistochemistry, gene expression, DNA methylation, copy number, and mutational profiles. In vivo drug sensitivity of targeted therapeutics was associated with distinct molecular tumor subgroups and specific genetic alterations. These models and their molecular characterization provide an unprecedented resource for the cancer community to study key oncogenic drivers and to evaluate novel treatment strategies.",
+    "studyType": "Other",
+    "title": "A biobank of patient-derived pediatric brain tumor models"
+  },
+  {
+    "alias": "ena-STUDY-dkfz_b062-10-10-2017-12:54:56:165-253",
+    "centerName": "dkfz_b062",
+    "creationTime": "2017-10-10T10:59.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001003940",
+      "EGAD00001003966",
+      "EGAD00001003973",
+      "EGAD00001003979"
+    ],
+    "description": "Genomic sequencing has driven precision-based oncology therapy; however, genetic drivers remain unknown or non-targetable for many malignancies, demanding alternative approaches to identify therapeutic leads. Ependymomas are chemotherapy-resistant brain tumours, which, despite genomic sequencing, lack effective molecular targets. Here, we mapped active chromatin landscapes in 42 primary ependymomas in two non-overlapping primary ependymoma cohorts. Enhancer regions revealed novel oncogenes, molecular targets, and pathways, which when subjected to small molecule inhibitor or shRNA treatment, increased survival and slowed proliferation in mouse and neurosphere patient-derived models of ependymomas. This study represents one of the largest enhancer mapping study of any cancer type to date, and provides a framework for target and drug discovery for other cancers recalcitrant to therapeutic development because of their lack of known genetic drivers.",
+    "egaStableId": "EGAS00001002696",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-05-22T22:00.000Z",
+    "studyAbstract": "Genomic sequencing has driven precision-based oncology therapy; however, genetic drivers remain unknown or non-targetable for many malignancies, demanding alternative approaches to identify therapeutic leads. Ependymomas are chemotherapy-resistant brain tumours, which, despite genomic sequencing, lack effective molecular targets. Here, we mapped active chromatin landscapes in 42 primary ependymomas in two non-overlapping primary ependymoma cohorts. Enhancer regions revealed novel oncogenes, molecular targets, and pathways, which when subjected to small molecule inhibitor or shRNA treatment, increased survival and slowed proliferation in mouse and neurosphere patient-derived models of ependymomas. This study represents one of the largest enhancer mapping study of any cancer type to date, and provides a framework for target and drug discovery for other cancers recalcitrant to therapeutic development because of their lack of known genetic drivers.",
+    "studyType": "Other",
+    "title": "Therapeutic Targeting of Ependymoma as Informed by Oncogenic Enhancer Profiling"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-HIPO-03-11-2017-15:22:57:743-41",
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2017-11-03T14:59.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001003965"
+    ],
+    "description": "Personalized cancer therapy aims at individual genetic changes characterizing primary cancers. Still, however, metastasis is the major clinically unmet problem, also due to an incomplete understanding of its molecular evolution.This study is the first to define the metastasis-specific whole genome landscape of human colorectal primary vs. matched metastatic lesions.Protein coding, ncRNA genes and 3’UTRs harbored about a third each of single nucleotide variations (SNVs)/indels, 19% of them being metastasis-specific. We found novel mutational hills among ncRNAs and 3’UTRs, copy number changes able to explain changes in microRNA expression in metastases, and novel metastasis-specific mutations in the 3’UTRs on important cancer signalling genes. Some metastatic lesions showed targetable mutations not detected in the primaries. Analysis of mutual exclusivity patterns supported a model that has progressive alterations in important colorectal cancer genes and revealed new partners. Metastatic lesions were enriched in SNVs, specific structural variations, and alterations in genes affecting cell adhesion and extracellular matrix interaction.Furthermore, a hepatic stellate activation cascade was enriched in metastases, suggesting genetic programs for site-specific colonization. Allele frequency distribution and mutational signature analysis suggests a common ancestor clone to both the primary tumor and the metastasis, with additional mutagenesis ongoing in both sites independently. Taken together, our results significantly add to hypothesis generation on metastasis evolution, and suggest novel metastasis-specific genomic changes which would be missed by current personalized therapy concepts.  (HIPO-032)",
+    "egaStableId": "EGAS00001002717",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-09-26T22:00.000Z",
+    "studyAbstract": "Personalized cancer therapy aims at individual genetic changes characterizing primary cancers. Still, however, metastasis is the major clinically unmet problem, also due to an incomplete understanding of its molecular evolution.This study is the first to define the metastasis-specific whole genome landscape of human colorectal primary vs. matched metastatic lesions.Protein coding, ncRNA genes and 3’UTRs harbored about a third each of single nucleotide variations (SNVs)/indels, 19% of them being metastasis-specific. We found novel mutational hills among ncRNAs and 3’UTRs, copy number changes able to explain changes in microRNA expression in metastases, and novel metastasis-specific mutations in the 3’UTRs on important cancer signalling genes. Some metastatic lesions showed targetable mutations not detected in the primaries. Analysis of mutual exclusivity patterns supported a model that has progressive alterations in important colorectal cancer genes and revealed new partners. Metastatic lesions were enriched in SNVs, specific structural variations, and alterations in genes affecting cell adhesion and extracellular matrix interaction.Furthermore, a hepatic stellate activation cascade was enriched in metastases, suggesting genetic programs for site-specific colonization. Allele frequency distribution and mutational signature analysis suggests a common ancestor clone to both the primary tumor and the metastasis, with additional mutagenesis ongoing in both sites independently. Taken together, our results significantly add to hypothesis generation on metastasis evolution, and suggest novel metastasis-specific genomic changes which would be missed by current personalized therapy concepts.  (HIPO-032)",
+    "studyType": "Other",
+    "title": "Defining the metastasome in colorectal cancer: Implications for hypotheses on metastasis evolution and personalized therapy (HIPO-032)"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-HIPO-06-11-2017-11:29:19:108-138",
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2017-11-06T10:21.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001004825"
+    ],
+    "description": "HIPO project: HIPO_021\nImportance: Chordomas are rare tumors of the axial skeleton and skull base with few therapeutic options and no clinically validated molecular drug targets. The value of comprehensive genomic analyses for guiding medical therapy of patients with advanced-stage chordoma is unknown.Objective: To identify therapeutically tractable genetic lesions in a cohort of chordoma patients within a genomics-guided precision oncology program and to document the outcome of individualized, molecularly targeted chordoma therapy.Design, Setting, and Participants: We performed whole-exome sequencing of tumor and matched germline control samples from seven patients with locally advanced or metastatic chordoma who were enrolled in a cross-institutional molecular stratification registry trial for younger adults with advanced-stage cancer across all histologies and patients with rare tumors. All patients were heavily pretreated and had progressive disease prior to molecular analysis.Interventions: Individualized medical therapy was administered according to the patients’ molecular profiles.Main Outcomes and Measures: Candidate therapeutic targets identified by whole-exome sequencing and response to genotype-directed therapy.Results: All patients harbored alterations of two or more genes known to be involved in DNA repair via homologous recombination (HR), including heterozygous deletions of ERCC6, FANC family members, RAD51L (n = 6), BRCA2 (n = 5), ATR, CHEK2, RAD18, RAD51B, and XRCC3 (n = 4); inactivating PTEN mutations coupled with loss of heterozygosity (n = 2); and pathogenic germline variants in BRCA2 (n = 1), NBN (n = 1), and CHEK2 (n = 1) that were accompanied by somatic deletion of the corresponding wild-type alleles. Consistently, a mutational signature associated with defective HR was enriched in all samples and co-occurred with extensive genomic instability, as evidenced by HR deficiency scores and high numbers of large-scale state transitions. These results prompted off-label treatment with the poly(ADP-ribose) polymerase (PARP) inhibitor olaparib in a patient whose tumor was refractory to irradiation and systemic treatment with imatinib, which led to a prolonged response and substantial clinical improvement.Conclusions and Relevance: Advanced-stage chordomas are frequently characterized by genomic imprints of defective HR DNA repair. HR deficiency represents a new therapeutic opportunity in this intractable disease through repositioning of PARP inhibitors that warrants further exploration in clinical trials.",
+    "egaStableId": "EGAS00001002720",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2019-03-11T23:00.000Z",
+    "studyAbstract": "HIPO project: HIPO_021\nImportance: Chordomas are rare tumors of the axial skeleton and skull base with few therapeutic options and no clinically validated molecular drug targets. The value of comprehensive genomic analyses for guiding medical therapy of patients with advanced-stage chordoma is unknown.Objective: To identify therapeutically tractable genetic lesions in a cohort of chordoma patients within a genomics-guided precision oncology program and to document the outcome of individualized, molecularly targeted chordoma therapy.Design, Setting, and Participants: We performed whole-exome sequencing of tumor and matched germline control samples from seven patients with locally advanced or metastatic chordoma who were enrolled in a cross-institutional molecular stratification registry trial for younger adults with advanced-stage cancer across all histologies and patients with rare tumors. All patients were heavily pretreated and had progressive disease prior to molecular analysis.Interventions: Individualized medical therapy was administered according to the patients’ molecular profiles.Main Outcomes and Measures: Candidate therapeutic targets identified by whole-exome sequencing and response to genotype-directed therapy.Results: All patients harbored alterations of two or more genes known to be involved in DNA repair via homologous recombination (HR), including heterozygous deletions of ERCC6, FANC family members, RAD51L (n = 6), BRCA2 (n = 5), ATR, CHEK2, RAD18, RAD51B, and XRCC3 (n = 4); inactivating PTEN mutations coupled with loss of heterozygosity (n = 2); and pathogenic germline variants in BRCA2 (n = 1), NBN (n = 1), and CHEK2 (n = 1) that were accompanied by somatic deletion of the corresponding wild-type alleles. Consistently, a mutational signature associated with defective HR was enriched in all samples and co-occurred with extensive genomic instability, as evidenced by HR deficiency scores and high numbers of large-scale state transitions. These results prompted off-label treatment with the poly(ADP-ribose) polymerase (PARP) inhibitor olaparib in a patient whose tumor was refractory to irradiation and systemic treatment with imatinib, which led to a prolonged response and substantial clinical improvement.Conclusions and Relevance: Advanced-stage chordomas are frequently characterized by genomic imprints of defective HR DNA repair. HR deficiency represents a new therapeutic opportunity in this intractable disease through repositioning of PARP inhibitors that warrants further exploration in clinical trials.",
+    "studyType": "Other",
+    "title": "Defective Homologous Recombination DNA Repair as Therapeutic Target in Advanced-Stage Chordoma (HIPO_021)"
+  },
+  {
+    "alias": "ena-STUDY-DKFZ-HIPO-15-12-2017-09:21:38:637-158",
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2017-12-15T08:09.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001004068"
+    ],
+    "description": "We used whole-genome and transcriptome sequencing to identify clinically actionable gene fusions in young adults with KRAS wild-type (KRASwt) pancreatic ductal adenocarcinoma (PDAC). These alterations included recurrent NRG1 rearrangements predicted to drive PDAC development through aberrant ERBB receptor-mediated signaling, and pharmacologic ERBB inhibition resulted in clinical improvement and remission of liver metastases in two patients with NRG1-rearranged tumors that had proved resistant to standard treatment. Our findings demonstrate that systematic screening of KRASwt tumors for oncogenic fusion genes will substantially improve the therapeutic prospects for a sizeable fraction of PDAC patients.",
+    "egaStableId": "EGAS00001002759",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-05-24T22:00.000Z",
+    "studyAbstract": "We used whole-genome and transcriptome sequencing to identify clinically actionable gene fusions in young adults with KRAS wild-type (KRASwt) pancreatic ductal adenocarcinoma (PDAC). These alterations included recurrent NRG1 rearrangements predicted to drive PDAC development through aberrant ERBB receptor-mediated signaling, and pharmacologic ERBB inhibition resulted in clinical improvement and remission of liver metastases in two patients with NRG1-rearranged tumors that had proved resistant to standard treatment. Our findings demonstrate that systematic screening of KRASwt tumors for oncogenic fusion genes will substantially improve the therapeutic prospects for a sizeable fraction of PDAC patients.",
+    "studyType": "Other",
+    "title": "NRG1 Fusions in KRAS Wild-type Pancreatic Cancer (H021)"
+  },
+  {
+    "alias": "5b4dd757-9a4a-46fc-9133-d1dcd645fb53",
+    "centerName": "CRG",
+    "creationTime": "2018-05-25T12:38.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001004132"
+    ],
+    "description": "In recent years, Next Generation Sequencing (NGS) has become a cornerstone of clinical genetics and diagnostics. Many clinical applications require high precision, especially if rare events such as somatic mutations in cancer or genetic variants causing rare diseases need to be identified. Although random sequencing errors can be modeled statistically and deep sequencing minimizes their impact, systematic errors remain a problem even at high depth of coverage. Understanding their source is crucial to increase precision of clinical NGS applications. In this work, we studied the relation between recurrent biases in allele balance (AB), systematic errors and false positive variant calls across a large cohort of human samples analyzed by whole exome sequencing (WES). We have modeled the allele balance distribution for biallelic genotypes in 987 WES samples in order to identify positions recurrently deviating significantly from the expectation, a phenomenon we termed allele balance bias (ABB). Furthermore, we have developed a genotype callability score based on ABB for all positions of the human exome, which detects false positive variant calls that passed state-of-the-art filters. Finally, we demonstrate the use of ABB for detection of false associations proposed by rare variant association studies (RVAS).",
+    "egaStableId": "EGAS00001003027",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-08-28T22:00.000Z",
+    "studyAbstract": "In recent years, Next Generation Sequencing (NGS) has become a cornerstone of clinical genetics and diagnostics. Many clinical applications require high precision, especially if rare events such as somatic mutations in cancer or genetic variants causing rare diseases need to be identified. Although random sequencing errors can be modeled statistically and deep sequencing minimizes their impact, systematic errors remain a problem even at high depth of coverage. Understanding their source is crucial to increase precision of clinical NGS applications. In this work, we studied the relation between recurrent biases in allele balance (AB), systematic errors and false positive variant calls across a large cohort of human samples analyzed by whole exome sequencing (WES). We have modeled the allele balance distribution for biallelic genotypes in 987 WES samples in order to identify positions recurrently deviating significantly from the expectation, a phenomenon we termed allele balance bias (ABB). Furthermore, we have developed a genotype callability score based on ABB for all positions of the human exome, which detects false positive variant calls that passed state-of-the-art filters. Finally, we demonstrate the use of ABB for detection of false associations proposed by rare variant association studies (RVAS).",
+    "studyType": "Other",
+    "title": "Allele Balance Bias Identifies Systematic Genotyping Errors and False Disease Associations"
+  },
+  {
+    "alias": "81ebb9cf-da1d-4c84-8be8-f44000e9cb8e",
+    "centerName": null,
+    "creationTime": "2018-07-31T13:32.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001004313"
+    ],
+    "description": "We established a platform for high-throughput confocal fluorescence microscopy and automated image analysis to perform large-scale drug response profiling with patient derived organoids (PDOs). Using PDO lines newly established from colorectal cancer patients with a standardized workflow, we performed chemical perturbations with more than 500 experimental and clinically used compounds. Subsequently, we captured approx. six million images by confocal microscopy. To analyze drug-induced PDO re-organization on a single organoid level we developed SCOPE, a software framework for automated PDO high-throughput image analysis. We observed a rich variety of divergent and reoccurring compound induced phenotypes in organoids. Perturbation of cellular processes, including signaling by MEK, GSK3β, cyclin dependent kinases (CDKs) and others, led to recurring and distinct architectural changes. Highlighting the clinical relevance, PDO viability was heterogeneous after perturbation with anticancer drugs and matched clinical response of corresponding colorectal cancer patients. Our work opens new avenues for image-based profiling for accelerated drug discovery and clinical decision-making.",
+    "egaStableId": "EGAS00001003140",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-08-29T22:00.000Z",
+    "studyAbstract": "We established a platform for high-throughput confocal fluorescence microscopy and automated image analysis to perform large-scale drug response profiling with patient derived organoids (PDOs). Using PDO lines newly established from colorectal cancer patients with a standardized workflow, we performed chemical perturbations with more than 500 experimental and clinically used compounds. Subsequently, we captured approx. six million images by confocal microscopy. To analyze drug-induced PDO re-organization on a single organoid level we developed SCOPE, a software framework for automated PDO high-throughput image analysis. We observed a rich variety of divergent and reoccurring compound induced phenotypes in organoids. Perturbation of cellular processes, including signaling by MEK, GSK3β, cyclin dependent kinases (CDKs) and others, led to recurring and distinct architectural changes. Highlighting the clinical relevance, PDO viability was heterogeneous after perturbation with anticancer drugs and matched clinical response of corresponding colorectal cancer patients. Our work opens new avenues for image-based profiling for accelerated drug discovery and clinical decision-making.",
+    "studyType": "Other",
+    "title": "Automated image-based profiling of complex drug induced phenotypes in patient-derived organoids"
+  },
+  {
+    "alias": "a59fe2b9-cf0c-408d-a52e-d716bfb746e5",
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2018-08-30T14:34.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001004563",
+      "EGAD00001004564",
+      "EGAD00001004565",
+      "EGAD00010001642",
+      "EGAD00010001643"
+    ],
+    "description": "IDHwt-glioblastomas rapidly recur after initial treatment. To study genetic evolution in glioblastoma, we analyzed whole genomes of 21 pairs of primary and recurrent tumor samples using next generation sequencing. In addition we sequenced RNA from 16 tumor pairs and a panel of 50 glioma-associated genes in tumor pairs from 43 patients (including 14 of the 21 patients included in the WGS discovery set). Glioblastoma subtypes were determined using 450k/EPIC methylation arrays.\n\nThis study was supported within the e:med program of the German Ministry of Education and Research (BMBF) by the collaborative research project ‘SYS-GLIO - Systems-based prediction of the biological and clinical behavior of gliomas’ (https://www.sys-med.de/de/demonstratoren/sys-glio/)\nThis study is part of the Heidelberg Center for Personalized Oncology - HIPO-043",
+    "egaStableId": "EGAS00001003184",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2019-01-17T23:00.000Z",
+    "studyAbstract": "IDHwt-glioblastomas rapidly recur after initial treatment. To study genetic evolution in glioblastoma, we analyzed whole genomes of 21 pairs of primary and recurrent tumor samples using next generation sequencing. In addition we sequenced RNA from 16 tumor pairs and a panel of 50 glioma-associated genes in tumor pairs from 43 patients (including 14 of the 21 patients included in the WGS discovery set). Glioblastoma subtypes were determined using 450k/EPIC methylation arrays.\n\nThis study was supported within the e:med program of the German Ministry of Education and Research (BMBF) by the collaborative research project ‘SYS-GLIO - Systems-based prediction of the biological and clinical behavior of gliomas’ (https://www.sys-med.de/de/demonstratoren/sys-glio/)\nThis study is part of the Heidelberg Center for Personalized Oncology - HIPO-043",
+    "studyType": "Other",
+    "title": "Analysis of IDHwt-glioblastoma samples from paired primary and recurrent tumor samples"
+  },
+  {
+    "alias": "29a5852a-8105-4ae1-88ed-0786fad0ccd9",
+    "centerName": null,
+    "creationTime": "2018-10-04T09:17.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001004459"
+    ],
+    "description": "We compared 12 pediatric T cell acute lymphoblastic leukemias collected at initial diagnosis and relapse with their corresponding PDX models. The analysis was performed on genomic level (whole genome sequencing (WGS), whole exome sequencing (WES), multiplex ligation probe amplification (MLPA), targeted sequencing) and the epigenetic level (DNA methylation, Assay for Transposase-Accessible Chromatin sequencing (ATAC-seq)). In sum, this study underlines the remarkable genomic stability, and for the first time documents the preservation of the epigenomic landscape in T-ALL-derived PDX models.",
+    "egaStableId": "EGAS00001003248",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-11-15T23:00.000Z",
+    "studyAbstract": "We compared 12 pediatric T cell acute lymphoblastic leukemias collected at initial diagnosis and relapse with their corresponding PDX models. The analysis was performed on genomic level (whole genome sequencing (WGS), whole exome sequencing (WES), multiplex ligation probe amplification (MLPA), targeted sequencing) and the epigenetic level (DNA methylation, Assay for Transposase-Accessible Chromatin sequencing (ATAC-seq)). In sum, this study underlines the remarkable genomic stability, and for the first time documents the preservation of the epigenomic landscape in T-ALL-derived PDX models.",
+    "studyType": "Other",
+    "title": "Epigenetics/genetics of the patient-derived xenografts of pediatric T-cell leukemia"
+  },
+  {
+    "alias": "ena-STUDY-EMBL-05-12-2018-23:48:15:185-257",
+    "centerName": null,
+    "creationTime": "2018-12-05T22:17.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001004499"
+    ],
+    "description": "In this study, we aimed to identify somatic structural variation of T-cell acute lymphoblastic leukemias (T-ALLs_ from patient-derived xenografts (PDX) at the single-cell level. For this purpose, we performed strand-specific single-cell sequencing of PDX-derived T-ALL relapse samples from two juvenile patients  (P1, P33). To validate structural variation detected via scTRIP, we profiled whole exome sequencing (WES) data from P33 (samples taken during initial disease, remission, relapse), and mate-pair sequencing data from P1 (relapse).",
+    "egaStableId": "EGAS00001003365",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2018-12-16T23:00.000Z",
+    "studyAbstract": "In this study, we aimed to identify somatic structural variation of T-cell acute lymphoblastic leukemias (T-ALLs_ from patient-derived xenografts (PDX) at the single-cell level. For this purpose, we performed strand-specific single-cell sequencing of PDX-derived T-ALL relapse samples from two juvenile patients  (P1, P33). To validate structural variation detected via scTRIP, we profiled whole exome sequencing (WES) data from P33 (samples taken during initial disease, remission, relapse), and mate-pair sequencing data from P1 (relapse).",
+    "studyType": "Other",
+    "title": "Finding structural variation from the patient-derived xenografts of pediatric T-cell leukemia at the single-cell level"
+  },
+  {
+    "alias": "de8782ae-01c1-4624-b582-91ee76140c4e",
+    "centerName": null,
+    "creationTime": "2018-12-12T14:20.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001004574"
+    ],
+    "description": "Monitoring the mutational patterns of solid tumors during cancer therapy is a major challenge in oncology. Analysis of mutations in cell free (cf) DNA offers a non-invasive approach to detect mutations that may be prognostic for disease survival or predictive for primary or secondary drug resistance. A main challenge for the application of cfDNA as a diagnostic tool is the diverse mutational landscape of cancer. Here, we developed a flexible end-to-end experimental and bioinformatics workflow to analyze mutations in cfDNA using custom amplicon sequencing. Our approach relies on open software tools to select primers suitable for multiplex PCR using minimal cfDNA as input. In addition, we developed a robust linear model to identify specific genetic alterations from sequencing data of cfDNA. We used our method to design a custom amplicon panel suitable for detection of hotspot mutations relevant for colorectal cancer and analyzed mutations in serial cfDNA samples from 34 patients with advanced colorectal cancer. Our data demonstrates that recurrent and patient-specific mutational patterns can be reliably detected for the majority of patients. Furthermore, we show that the allele frequency of mutations in cfDNA correlates well with disease progression. Finally, we demonstrate that monitoring of cfDNA can outperform the predictive power of currently used tumor markers and reveal mechanisms of resistance to anti-EGFR antibody treatment.",
+    "egaStableId": "EGAS00001003382",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2019-06-27T22:00.000Z",
+    "studyAbstract": "Monitoring the mutational patterns of solid tumors during cancer therapy is a major challenge in oncology. Analysis of mutations in cell free (cf) DNA offers a non-invasive approach to detect mutations that may be prognostic for disease survival or predictive for primary or secondary drug resistance. A main challenge for the application of cfDNA as a diagnostic tool is the diverse mutational landscape of cancer. Here, we developed a flexible end-to-end experimental and bioinformatics workflow to analyze mutations in cfDNA using custom amplicon sequencing. Our approach relies on open software tools to select primers suitable for multiplex PCR using minimal cfDNA as input. In addition, we developed a robust linear model to identify specific genetic alterations from sequencing data of cfDNA. We used our method to design a custom amplicon panel suitable for detection of hotspot mutations relevant for colorectal cancer and analyzed mutations in serial cfDNA samples from 34 patients with advanced colorectal cancer. Our data demonstrates that recurrent and patient-specific mutational patterns can be reliably detected for the majority of patients. Furthermore, we show that the allele frequency of mutations in cfDNA correlates well with disease progression. Finally, we demonstrate that monitoring of cfDNA can outperform the predictive power of currently used tumor markers and reveal mechanisms of resistance to anti-EGFR antibody treatment.",
+    "studyType": "Other",
+    "title": "Detection of mutational patterns in cell free DNA (cfDNA) of colorectal cancer by custom amplicon sequencing"
+  },
+  {
+    "alias": "5363ff77-ce18-45a1-9e0e-b8a0bacd0fbe",
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2018-12-19T13:27.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001005113"
+    ],
+    "description": "The mutational status of GIST analyzed with a broad sequencing approach (WES, RNAseq)",
+    "egaStableId": "EGAS00001003405",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2019-07-02T22:00.000Z",
+    "studyAbstract": "The mutational status of GIST analyzed with a broad sequencing approach (WES, RNAseq)",
+    "studyType": "Other",
+    "title": "KIT-dependent and -independent genomic heterogeneity of resistance in gastrointestinal stromal tumors - TORC1/2 inhibition as salvage strategy"
+  },
+  {
+    "alias": "1895a4d8-3418-4848-b1cc-3f1ec190c384",
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2019-02-15T14:52.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001005021",
+      "EGAD00001005061"
+    ],
+    "description": "DNA methylation patterns delineate clinically relevant subgroups of meningioma. We previously established the six meningioma methylation classes (MC) benign-1, 2, 3, intermediate-A, B and malignant.\n\nHere, we set out to identify subgroup-specific mutational patterns and pathway regulation. Whole-genome-sequencing was performed on 62 samples across all MCs and WHO grades from 62 patients with matched blood control, including 40 sporadic and 22 radiation-induced (Mrad) meningiomas. RNA sequencing was added for 18 cases and chromatin-immunoprecipitation for the enhancer mark H3K27ac followed by sequencing (ChIP-seq) for 16 samples.\n\nBesides the known mutations in meningioma, structural alterations were found to contribute to the spectrum of mechanisms inactivating NF2 in sporadic meningioma similar to previous reports for Mrad. Aberrations of DMD were found to be enriched in MCs with NF2 mutations and DMD was among the most differentially upregulated genes in NF2 mutant compared to NF2 wild-type cases. The mutational signature AC3 was detected in both sporadic meningioma and Mrad, but distributed across the genome in sporadic cases and enriched near genomic breakpoints in Mrad. In general, the malignant MC presented a significantly higher exposure to AC3 and higher genomic instability beyond the mutational load than the other MCs. Pathway analysis of the ChIP-seq clusters revealed that the FOXM1 is most differentially activated in high-grade cases, along with super enhancer recruitment near HOX genes and respective upregulation of expression.\n\nThis data further elucidate the biological mechanisms differentiating meningiomas of different WHO grade and epigenetic subgroups and suggest leveraging the genomic instability as novel therapeutic targets.",
+    "egaStableId": "EGAS00001003481",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2019-05-16T22:00.000Z",
+    "studyAbstract": "DNA methylation patterns delineate clinically relevant subgroups of meningioma. We previously established the six meningioma methylation classes (MC) benign-1, 2, 3, intermediate-A, B and malignant.\n\nHere, we set out to identify subgroup-specific mutational patterns and pathway regulation. Whole-genome-sequencing was performed on 62 samples across all MCs and WHO grades from 62 patients with matched blood control, including 40 sporadic and 22 radiation-induced (Mrad) meningiomas. RNA sequencing was added for 18 cases and chromatin-immunoprecipitation for the enhancer mark H3K27ac followed by sequencing (ChIP-seq) for 16 samples.\n\nBesides the known mutations in meningioma, structural alterations were found to contribute to the spectrum of mechanisms inactivating NF2 in sporadic meningioma similar to previous reports for Mrad. Aberrations of DMD were found to be enriched in MCs with NF2 mutations and DMD was among the most differentially upregulated genes in NF2 mutant compared to NF2 wild-type cases. The mutational signature AC3 was detected in both sporadic meningioma and Mrad, but distributed across the genome in sporadic cases and enriched near genomic breakpoints in Mrad. In general, the malignant MC presented a significantly higher exposure to AC3 and higher genomic instability beyond the mutational load than the other MCs. Pathway analysis of the ChIP-seq clusters revealed that the FOXM1 is most differentially activated in high-grade cases, along with super enhancer recruitment near HOX genes and respective upregulation of expression.\n\nThis data further elucidate the biological mechanisms differentiating meningiomas of different WHO grade and epigenetic subgroups and suggest leveraging the genomic instability as novel therapeutic targets.",
+    "studyType": "Other",
+    "title": "Mutational patterns and regulatory networks in epigenetic subgroups of meningioma (H033)"
+  },
+  {
+    "alias": "b640329f-a77b-4228-8fc7-0a7b5faf5cb8",
+    "centerName": "DKFZ-HIPO",
+    "creationTime": "2019-07-26T09:04.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001005249"
+    ],
+    "description": "",
+    "egaStableId": "EGAS00001003776",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2019-11-27T23:00.000Z",
+    "studyAbstract": "Neurofibroma/schwannoma hybrid nerve sheath tumors (N/S HNSTs) are neoplasms associated with larger nerves that occur sporadically and in the context of schwannomatosis or neurofibromatosis (NF). Clinical management of N/S HNST is challenging, especially for large tumors, and established systemic treatments are lacking. We identified activating mutations (p.Leu755Ser, p.Asp769Tyr, p.Val777Leu) in the catalytic domain of the ERBB2 receptor tyrosine kinase in schwannomatosis-associated (4 of 8 patients) N/S HNSTs but not in tumors arising in the context of NF (0 of 6 patients), and observed that ERBB2-mutant N/S HNSTs define a distinct subgroup of peripheral nerve sheath tumors based on genome-wide DNA methylation patterns. The small-molecule ERBB inhibitor lapatinib led to prolonged clinical benefit and a lasting radiographic and metabolic response in a patient with schwannomatosis-associated, ERBB2-mutant N/S HNST. These findings uncover a key biological feature of N/S HNST that may have important diagnostic and therapeutic implications. (H021)",
+    "studyType": "Cancer Genomics",
+    "title": "Targetable ERBB2 Mutations in Neurofibroma/Schwannoma Hybrid Nerve Sheath Tumors"
+  },
+  {
+    "alias": "60445aa0-34f1-4f4b-90ae-d74a03f9ae31",
+    "centerName": null,
+    "creationTime": "2019-10-01T09:41.000Z",
+    "customTags": null,
+    "datasets": [
+      "EGAD00001005370"
+    ],
+    "description": "Progress in the systemic control of osteosarcoma has been limited over the past decades thus indicating the urgent clinical need for the development of novel treatment strategies. Therefore, we have recently developed new preclinical models to study promising novel agents for the treatment of pediatric osteosarcoma. The checkpoint kinase (chk) inhibitor prexasertib (LY2606368) and its salt form (LSN2940930) have recently been shown to be active in adult and pediatric malignancies, including sarcoma. We have now tested the potency of prexasertib in clonogenic survival assays in two new lines of primary patient-derived osteosarcoma cells and in two established osteosarcoma cell lines as a single agent and in combination with cisplatin and the poly ADP-ribose polymerase (PARP) inhibitor talazoparib. Prexasertib alone results in strongly reduced clonogenic survival at low nanomolar concentrations and acts by affecting cell cycle progression, induction of apoptosis and induction of double-stranded DNA breakage at concentrations that are well below clinically tolerable and safe plasma concentrations. In combination with cisplatin and talazoparib, prexasertib acts in a synergistic fashion. Chk1 inhibition by prexasertib and its combination with the DNA damaging agent cisplatin and the PARP-inhibitor talazoparib thus emerges as a potential new treatment option for pediatric osteosarcoma which will now have to be tested in preclinical primary patient derived in vivo models and clinical studies.",
+    "egaStableId": "EGAS00001003923",
+    "pubMedIds": null,
+    "published": true,
+    "released": "RELEASED",
+    "releasedDate": "2019-11-21T23:00.000Z",
+    "studyAbstract": "Progress in the systemic control of osteosarcoma has been limited over the past decades thus indicating the urgent clinical need for the development of novel treatment strategies. Therefore, we have recently developed new preclinical models to study promising novel agents for the treatment of pediatric osteosarcoma. The checkpoint kinase (chk) inhibitor prexasertib (LY2606368) and its salt form (LSN2940930) have recently been shown to be active in adult and pediatric malignancies, including sarcoma. We have now tested the potency of prexasertib in clonogenic survival assays in two new lines of primary patient-derived osteosarcoma cells and in two established osteosarcoma cell lines as a single agent and in combination with cisplatin and the poly ADP-ribose polymerase (PARP) inhibitor talazoparib. Prexasertib alone results in strongly reduced clonogenic survival at low nanomolar concentrations and acts by affecting cell cycle progression, induction of apoptosis and induction of double-stranded DNA breakage at concentrations that are well below clinically tolerable and safe plasma concentrations. In combination with cisplatin and talazoparib, prexasertib acts in a synergistic fashion. Chk1 inhibition by prexasertib and its combination with the DNA damaging agent cisplatin and the PARP-inhibitor talazoparib thus emerges as a potential new treatment option for pediatric osteosarcoma which will now have to be tested in preclinical primary patient derived in vivo models and clinical studies.",
+    "studyType": "Other",
+    "title": "WES of 2 human osteosarcoma and corresponding cell lines"
+  }
+]

--- a/ega-examples/transformed/README.md
+++ b/ega-examples/transformed/README.md
@@ -1,6 +1,6 @@
 # Transformed GHGA-compatible EGA JSON
 
-This folder consists of EGA metadata JSON transformed from [../original].
+This folder consists of EGA metadata JSON transformed from [../original]().
 
 To transform the original JSON to a GHGA compatible form:
 
@@ -8,6 +8,5 @@ To transform the original JSON to a GHGA compatible form:
 python ../../scripts/translate_ega_to_ghga.py \
     --ega-dac-json ../original/dacs.json \
     --ega-dataset-json ../original/datasets.json \
-    --ega-studies-json ../original/studies.json \
-    --output-prefix ghga
+    --ega-studies-json ../original/studies.json
 ```

--- a/ega-examples/transformed/README.md
+++ b/ega-examples/transformed/README.md
@@ -1,0 +1,13 @@
+# Transformed GHGA-compatible EGA JSON
+
+This folder consists of EGA metadata JSON transformed from [../original].
+
+To transform the original JSON to a GHGA compatible form:
+
+```sh
+python ../../scripts/translate_ega_to_ghga.py \
+    --ega-dac-json ../original/dacs.json \
+    --ega-dataset-json ../original/datasets.json \
+    --ega-studies-json ../original/studies.json \
+    --output-prefix ghga
+```

--- a/ega-examples/transformed/README.md
+++ b/ega-examples/transformed/README.md
@@ -1,6 +1,6 @@
 # Transformed GHGA-compatible EGA JSON
 
-This folder consists of EGA metadata JSON transformed from [../original]().
+This folder consists of EGA metadata JSON transformed from the [original EGA JSON](../original/).
 
 To transform the original JSON to a GHGA compatible form:
 

--- a/ega-examples/transformed/data_access_committees.json
+++ b/ega-examples/transformed/data_access_committees.json
@@ -1,0 +1,130 @@
+{
+    "data_access_committees": [
+        {
+            "id": "EGAC00001000165",
+            "title": "Neuromics Data Access Committee",
+            "main_contact": null,
+            "xref": [
+                "ena-DAC-NEUROMICS-06-02-2014-23:56:38:036-41"
+            ],
+            "creation_date": "2014-02-06T22:21.000Z"
+        },
+        {
+            "id": "EGAC00001000217",
+            "title": "Data Access Committee for German Consortium for Translational Cancer Research (DKTK)",
+            "main_contact": "EGAC00001000217",
+            "xref": [
+                "ena-DAC-DKFZ-IBIOS-30-07-2014-08:33:05:360-399"
+            ],
+            "creation_date": "2014-07-30T06:16.000Z"
+        },
+        {
+            "id": "EGAC00001000219",
+            "title": "Data Access Committee of divisions B060 and B062, German Cancer Research Center (DKFZ)",
+            "main_contact": "EGAC00001000219",
+            "xref": [
+                "ena-DAC-DKFZ-IBIOS-31-07-2014-15:32:43:877-13"
+            ],
+            "creation_date": "2014-07-31T13:54.000Z"
+        },
+        {
+            "id": "EGAC00001000317",
+            "title": "DAC for Tuebingen-Stuttgart cohort",
+            "main_contact": "EGAC00001000317",
+            "xref": [
+                "ena-DAC-TUSCO-27-02-2015-13:57:59:212-261"
+            ],
+            "creation_date": "2015-02-27T12:20.000Z"
+        },
+        {
+            "id": "EGAC00001000346",
+            "title": "Bioinformatics of Data Analysis (B240)",
+            "main_contact": "EGAC00001000346",
+            "xref": [
+                "ena-DAC-DKFZ-IBIOS-01-06-2015-11:13:45:832-184"
+            ],
+            "creation_date": "2015-06-01T09:58.000Z"
+        },
+        {
+            "id": "EGAC00001000381",
+            "title": "MMML associated cell line data",
+            "main_contact": "EGAC00001000381",
+            "xref": [
+                "ena-DAC-DKFZ-IBIOS-28-08-2015-10:49:04:108-238"
+            ],
+            "creation_date": "2015-08-28T08:15.000Z"
+        },
+        {
+            "id": "EGAC00001000452",
+            "title": "DKFZ-HIPO Data Access Committee of Heidelberg Center for Personalized Oncology",
+            "main_contact": null,
+            "xref": [
+                "ena-DAC-DKFZ-HIPO-17-03-2016-10:18:52:050-451"
+            ],
+            "creation_date": "2016-03-17T09:54.000Z"
+        },
+        {
+            "id": "EGAC00001000470",
+            "title": "University of Heidelberg_MUO",
+            "main_contact": "EGAC00001000470",
+            "xref": [
+                "ena-DAC-MUO-19-04-2016-11:21:22:457-63"
+            ],
+            "creation_date": "2016-04-19T09:24.000Z"
+        },
+        {
+            "id": "EGAC00001000916",
+            "title": "ABB DAC",
+            "main_contact": "EGAC00001000916",
+            "xref": [
+                "68a8c5d2-7f64-4d4c-974b-365370badf61"
+            ],
+            "creation_date": "2018-05-25T12:31.000Z"
+        },
+        {
+            "id": "EGAC00001000998",
+            "title": "Colorectal Cancer Organoids Data Access Committee",
+            "main_contact": "EGAC00001000998",
+            "xref": [
+                "4000883f-cae0-4390-941f-bd84577b4af2"
+            ],
+            "creation_date": "2018-08-27T10:03.000Z"
+        },
+        {
+            "id": "EGAC00001001033",
+            "title": "T-ALL research group at the University Hospital in Heidelberg, Germany",
+            "main_contact": "EGAC00001001033",
+            "xref": [
+                "07d65c87-c5ac-4321-a66c-1544bf6e9c0f"
+            ],
+            "creation_date": "2018-10-04T11:07.000Z"
+        },
+        {
+            "id": "EGAC00001001091",
+            "title": "EMBL genome biology research group for structural variation (Strand-seq application)",
+            "main_contact": "EGAC00001001091",
+            "xref": [
+                "ena-DAC-EMBL-06-12-2018-01:42:26:025-259"
+            ],
+            "creation_date": "2018-12-06T00:29.000Z"
+        },
+        {
+            "id": "EGAC00001001113",
+            "title": "Mannheim Liquid Biopsy Unit, Heidelberg University &amp; DKFZ",
+            "main_contact": "EGAC00001001113",
+            "xref": [
+                "a314bf37-8fd7-42f6-acfc-1926343abc38"
+            ],
+            "creation_date": "2019-01-15T10:23.000Z"
+        },
+        {
+            "id": "EGAC00001001337",
+            "title": "Osteosarcoma Study HD Data Access Commitee",
+            "main_contact": "EGAC00001001337",
+            "xref": [
+                "e7608108-a7eb-4475-b60c-974b916fb8fb"
+            ],
+            "creation_date": "2019-10-01T06:03.000Z"
+        }
+    ]
+}

--- a/ega-examples/transformed/data_access_policies.json
+++ b/ega-examples/transformed/data_access_policies.json
@@ -1,0 +1,64 @@
+{
+    "data_access_policies": [
+        {
+            "id": "EGAP00001000221",
+            "has_data_access_committee": "EGAC00001000219"
+        },
+        {
+            "id": "EGAP00001000441",
+            "has_data_access_committee": "EGAC00001000452"
+        },
+        {
+            "id": "EGAP00001000220",
+            "has_data_access_committee": "EGAC00001000217"
+        },
+        {
+            "id": "EGAP00001000335",
+            "has_data_access_committee": "EGAC00001000346"
+        },
+        {
+            "id": "EGAP00001000369",
+            "has_data_access_committee": "EGAC00001000381"
+        },
+        {
+            "id": "EGAP00001000456",
+            "has_data_access_committee": "EGAC00001000470"
+        },
+        {
+            "id": "EGAP00001000171",
+            "has_data_access_committee": "EGAC00001000165"
+        },
+        {
+            "id": "EGAP00001000687",
+            "has_data_access_committee": "EGAC00001000219"
+        },
+        {
+            "id": "EGAP00001000889",
+            "has_data_access_committee": "EGAC00001000916"
+        },
+        {
+            "id": "EGAP00001000962",
+            "has_data_access_committee": "EGAC00001000998"
+        },
+        {
+            "id": "EGAP00001001035",
+            "has_data_access_committee": "EGAC00001001033"
+        },
+        {
+            "id": "EGAP00001001056",
+            "has_data_access_committee": "EGAC00001001091"
+        },
+        {
+            "id": "EGAP00001001086",
+            "has_data_access_committee": "EGAC00001001113"
+        },
+        {
+            "id": "EGAP00001001314",
+            "has_data_access_committee": "EGAC00001001337"
+        },
+        {
+            "id": "EGAP00001000506",
+            "has_data_access_committee": "EGAC00001000317"
+        }
+    ]
+}

--- a/ega-examples/transformed/datasets.json
+++ b/ega-examples/transformed/datasets.json
@@ -1,0 +1,1133 @@
+{
+    "datasets": [
+        {
+            "id": "EGAD00001000174",
+            "title": "DATA_SET_Coverage_bias_sensitivity_of_variant_calling_for_4_WG_seq_tech",
+            "description": "DATA_SET_Coverage_bias_sensitivity_of_variant_calling_for_4_WG_seq_tech",
+            "type": [
+                "sample"
+            ],
+            "has_data_access_policy": "EGAP00001000221",
+            "xref": [
+                "DATA_SET_Coverage_bias_sensitivity_of_variant_calling_for_4_WG_seq_tech"
+            ],
+            "creation_date": "2012-05-08T06:34.000Z",
+            "has_study": "EGAS00001000274"
+        },
+        {
+            "id": "EGAD00001000366",
+            "title": "Whole genome bisufite sequencing for smoking and non-smoking mother-child pairs",
+            "description": "WGBS data of whole blood samples from smoking and non-smoking mothers and their children at gestation/birth and follow-up years.",
+            "type": [
+                "Methylation profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "DATA_SET_marlboro-EEP-2013-03-15"
+            ],
+            "creation_date": "2013-03-27T14:53.000Z",
+            "has_study": "EGAS00001000455"
+        },
+        {
+            "id": "EGAD00001000884",
+            "title": "Exome sequencing of serially transplanted genetically marked IC-enriched primary PDAC cultures.",
+            "description": "In order to elucidate whether newly acquired genetic alterations during serial transplantation of patient derived primary pancreatic cancer cultures contribute to the observed clonal dynamics in vivo, all coding genes of two patient derived primary cultures and derived genetically marked serial xenografts (1\u00b0/2\u00b0/3\u00b0) were sequenced.",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-17-07-2014-15:54:18:121-70"
+            ],
+            "creation_date": "2014-07-17T13:34.000Z",
+            "has_study": "EGAS00001000882"
+        },
+        {
+            "id": "EGAD00001000963",
+            "title": "Schwannomatosis WES data",
+            "description": "Exome sequencing of sporadic schwannomatosis patients",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000221",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-01-08-2014-08:47:40:399-28"
+            ],
+            "creation_date": "2014-08-01T06:01.000Z",
+            "has_study": "EGAS00001000767"
+        },
+        {
+            "id": "EGAD00001000964",
+            "title": "Schwannomatosis lcWGS data",
+            "description": "Low-coverage whole genome sequencing of sporadic schwannomatosis patients",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000221",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-01-08-2014-08:50:46:817-29"
+            ],
+            "creation_date": "2014-08-01T06:55.000Z",
+            "has_study": "EGAS00001000767"
+        },
+        {
+            "id": "EGAD00001000966",
+            "title": "WGBS data for ependymomas and normal controls (fetal and adult)",
+            "description": "Whole genome bisulfite sequencing data for 6 ependymomas plus 3 fetal controls (f1, f2, f4) and 3 adult controls (a2, a3, a4). See Mack, Witt et al. Nature 506(7489):445-50, 2014 (PMID: 24553142).",
+            "type": [
+                "Methylation profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000220",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-01-08-2014-15:53:49:885-84"
+            ],
+            "creation_date": "2014-08-01T13:59.000Z",
+            "has_study": "EGAS00001000443"
+        },
+        {
+            "id": "EGAD00001000992",
+            "title": "HIPO blastemal Wilms (nephroblastoma) CHIP sequencing samples",
+            "description": "HIPO blastemal Wilms (nephroblastoma) characterisation of tumor driving events caused by differential SIX1 binding of the SIX1 Q177R mutatns",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-28-08-2014-13:48:51:420-1011"
+            ],
+            "creation_date": "2014-08-28T11:02.000Z",
+            "has_study": "EGAS00001000906"
+        },
+        {
+            "id": "EGAD00001000993",
+            "title": "HIPO blastemal Wilms (nephroblastoma) RNA sequencing samples",
+            "description": "HIPO blastemal Wilms (nephroblastoma) characterisation of tumor driving gene expression events",
+            "type": [
+                "Transcriptome profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-28-08-2014-14:05:04:574-1012"
+            ],
+            "creation_date": "2014-08-28T12:15.000Z",
+            "has_study": "EGAS00001000906"
+        },
+        {
+            "id": "EGAD00001000994",
+            "title": "HIPO blastemal Wilms (nephroblastoma) WGS sequencing samples",
+            "description": "HIPO blastemal Wilms (nephroblastoma) characterisation of tumor driving chromosomal aberrations",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-28-08-2014-14:11:35:869-1013"
+            ],
+            "creation_date": "2014-08-28T12:46.000Z",
+            "has_study": "EGAS00001000906"
+        },
+        {
+            "id": "EGAD00001000995",
+            "title": "HIPO blastemal Wilms (nephroblastoma) exome sequencing samples",
+            "description": "HIPO blastemal Wilms (nephroblastoma) characterisation of tumor driving DNA alterations",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-28-08-2014-14:27:15:311-1014"
+            ],
+            "creation_date": "2014-08-28T12:27.000Z",
+            "has_study": "EGAS00001000906"
+        },
+        {
+            "id": "EGAD00001000997",
+            "title": "Chronic lymphocytic leukemia driven by paradoxical ERK activation during BRAF inhibitor treatment",
+            "description": "Whole-exome sequencing of a chronic lymphocytic leukemia (CLL) developed during vemurafenib treatment of a patient with malignant melanoma. Peripheral blood mononuclear cells were separated by Ficoll gradient centrifugation. DNA was extracted from highly purified (&gt;97%) CD19+CD5+ cells obtained from the patient while being under BRAF inhibition versus CD14+ germline control cells (&gt;90% purity). No alterations that could be linked to aberrant RAS activity or paradoxical RAF/MEK/ERK signaling could be identified in the CLL, which shows characteristic copy number alterations.",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-29-08-2014-08:27:40:831-1015"
+            ],
+            "creation_date": "2014-08-29T06:50.000Z",
+            "has_study": "EGAS00001000948"
+        },
+        {
+            "id": "EGAD00001001384",
+            "title": "Cooperative activity of BRAF F595L and mutant HRAS in histiocytic sarcoma provides new insights into oncogenic BRAF signaling",
+            "description": "Mutations that activate the RAF-MEK-ERK signaling pathway, in particular BRAFV600E, occur in many cancers, and mutant BRAF-selective inhibitors have clinical activity in these diseases. Activating BRAF alleles are usually considered to be mutually exclusive with mutant RAS, whereas inactivating mutations in the D594F595G596 motif of the BRAF activation segment can coexist with oncogenic RAS and cooperate via paradoxical MEK/ERK activation. We determined the functional consequences of a largely uncharacterized BRAF mutation, F595L, which was detected along with an HRASQ61R allele by clinical exome sequencing in a patient with histiocytic sarcoma and also occurs in epithelial cancers, melanoma, and neuroblastoma, and investigated its interaction with mutant RAS. We demonstrate that, unlike previously described DFG motif mutants, BRAFF595L is a gain-of-function variant with intermediate activity towards MEK that does not act paradoxically, but nevertheless cooperates with mutant RAS to promote oncogenic signaling. Of immediate clinical relevance, BRAFF595L shows divergent responses to different mutant BRAF-selective inhibitors, whereas signaling driven by BRAFF595L with and without mutant RAS is efficiently blocked by pan-RAF and MEK inhibitors. Mutation data from primary patient samples and cell lines show that BRAFF595L, as well as other BRAF mutations with intermediate activity, frequently coincide with mutant RAS in a broad spectrum of cancers. These data define a novel class of activating BRAF mutations that cooperate with oncogenic RAS in a non-paradoxical fashion to achieve an optimal level of MEK-ERK signaling, extend the spectrum of patients with systemic histiocytic disorders and other malignancies who are candidates for therapeutic blockade of the RAF-MEK-ERK pathway, and underscore the value of comprehensive genetic profiling for understanding the signaling requirements of individual cancers.",
+            "type": [
+                "sample"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-28-05-2015-11:13:32:451-82"
+            ],
+            "creation_date": "2015-05-28T09:43.000Z",
+            "has_study": "EGAS00001000948"
+        },
+        {
+            "id": "EGAD00001001386",
+            "title": "WGS Huh7 cell lines",
+            "description": "Whole Genome Sequencing of Huh7 cell lines",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000335",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-01-06-2015-13:43:18:542-193"
+            ],
+            "creation_date": "2015-06-01T11:33.000Z",
+            "has_study": "EGAS00001001252"
+        },
+        {
+            "id": "EGAD00001001444",
+            "title": "Atypical teratoid/rhabdoid tumors (ATRT) are comprised of three epigenetic subgroups with distinct enhancer landscapes",
+            "description": "Atypical teratoid/rhabdoid tumor (ATRT) is one of the most common brain tumors in infants and young children. Although the prognosis of ATRT patients is poor, some patients respond very well to current treatments, suggesting inter-tumor molecular heterogeneity. To investigate this further, we genetically and epigenetically analyzed a large cohort of ATRTs (n = 170). Three distinct molecular subgroups of ATRTs, associated with differences in demographics, tumor location and type of SMARCB1 alterations, were identified using DNA-methylation or gene expression analyses. Whole genome DNA- and RNA-sequencing found no other recurrent mutations explaining the differences between subgroups. However, whole genome bisulfite-sequencing and H3K27Ac ChIP-sequencing of primary tumors revealed clear differences in methylation patterns and enhancer landscapes, leading to the identification of subgroup-specific regulatory networks.",
+            "type": [
+                "Whole genome sequencing",
+                "Transcriptome profiling by high-throughput sequencing",
+                "Methylation profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-21-07-2015-14:09:30:309-81"
+            ],
+            "creation_date": "2015-07-21T12:53.000Z",
+            "has_study": "EGAS00001001297"
+        },
+        {
+            "id": "EGAD00001001468",
+            "title": "Four lymphoma cell lines (AGO2-PAR-CLIP)",
+            "description": "PAR-CLIP was performed on the Argonaute-2 protein (AGO2) in four lymphoma cell lines:NamalwaRajiSU-DHL-4SU-DHL-6",
+            "type": [
+                "Transcriptome profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000369",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-17-08-2015-09:13:01:216-19"
+            ],
+            "creation_date": "2015-08-17T07:17.000Z",
+            "has_study": "EGAS00001001394"
+        },
+        {
+            "id": "EGAD00001001598",
+            "title": "MYC and MINCR-regulated lncRNAs in hT-RPE-MycER cells",
+            "description": "RNA-sequencing data from teh hT-RPE-MycER cell line after MYC activation and after MINCR knock-down in conditions of MYC ON or OFF",
+            "type": [
+                "sample"
+            ],
+            "has_data_access_policy": "EGAP00001000369",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-28-08-2015-09:49:06:632-229"
+            ],
+            "creation_date": "2015-08-28T07:20.000Z",
+            "has_study": "EGAS00001001199"
+        },
+        {
+            "id": "EGAD00001001612",
+            "title": "RNA-Seq of novel miR (nmiR-1 and nmiR-2) overexpression and knockdown in BL",
+            "description": "After overexpression and knockdown of both described novel miRs nmiR-1 and nmiR-2 in BL cell lines (SU-DHL4 for nmiR-1 and Raji for nmiR-2), we performed regular RNA-Seq (including Mock controls for all cell lines) to identify their direct and indirect downstream mRNA targets.",
+            "type": [
+                "Transcriptome profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000369",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-16-09-2015-13:05:30:578-414"
+            ],
+            "creation_date": "2015-09-16T11:46.000Z",
+            "has_study": "EGAS00001001394"
+        },
+        {
+            "id": "EGAD00001002011",
+            "title": "RNA sequencing data of child-mother pairs, maternal smoking.",
+            "description": "RNA sequencing data of whole blood samples from smoking and non-smoking mothers and their children at gestation/birth and follow-up years.",
+            "type": [
+                "Transcriptome profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-12-04-2016-13:32:15:134-286"
+            ],
+            "creation_date": "2016-04-12T13:46.000Z",
+            "has_study": "EGAS00001000455"
+        },
+        {
+            "id": "EGAD00001002012",
+            "title": "ChIPseq data of child-mother pairs, maternal smoking.",
+            "description": "ChIPseq data of whole blood samples from smoking and non-smoking mothers and their children at gestation/birth and follow-up years.",
+            "type": [
+                "sample"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-12-04-2016-13:35:10:904-287"
+            ],
+            "creation_date": "2016-04-12T13:46.000Z",
+            "has_study": "EGAS00001000455"
+        },
+        {
+            "id": "EGAD00001002055",
+            "title": "H005 WES CLL",
+            "description": "Whole exome sequencing from matched tumor-control samples of 121 primary lymphoma samples. Sequencing was performed on Illumina HiSeq2000. The dataset contains FASTQ files.",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-22-04-2016-18:03:44:927-11"
+            ],
+            "creation_date": "2016-04-22T16:03.000Z",
+            "has_study": "EGAS00001001746"
+        },
+        {
+            "id": "EGAD00001002056",
+            "title": "H005 RNA-seq CLL",
+            "description": "Paired-end RNA sequencing using total RNA from 136 primary lymphoma samples. Sequencing was performed on the Illumina HiSeq2000 with 300bp insert size. The dataset contains FASTQ files.",
+            "type": [
+                "Transcriptome profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-22-04-2016-18:09:52:421-12"
+            ],
+            "creation_date": "2016-04-22T16:58.000Z",
+            "has_study": "EGAS00001001746"
+        },
+        {
+            "id": "EGAD00001002067",
+            "title": "Analysis of tumor periphery and center-specific mutations in renal cell carcinoma",
+            "description": "Renal cell carcinoma (RCC) is a genomically heterogeneous tumor. In the present project, the question whether intratumoral heterogeneity follows a zonal pattern indicating spatial niches was addressed. Whole exome sequencing of 16 paired samples from tumor periphery and center revealed a number of region-specific functional SNVs and Indels. Therefore, RCCs are not composed of evenly admixed tumor cells but show topological differences in their clonal composition.",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000456",
+            "xref": [
+                "ena-DATASET-MUO-27-04-2016-12:33:45:301-16"
+            ],
+            "creation_date": "2016-04-27T13:47.000Z",
+            "has_study": "EGAS00001001784"
+        },
+        {
+            "id": "EGAD00001002135",
+            "title": "ChIPseq data of Atypical teratoid/rhabdoid tumors (ATRT)",
+            "description": "ChIPseq data of Atypical teratoid/rhabdoid tumors (ATRT)",
+            "type": [
+                "sample"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-18-05-2016-08:44:36:254-32"
+            ],
+            "creation_date": "2016-05-18T11:03.000Z",
+            "has_study": "EGAS00001001297"
+        },
+        {
+            "id": "EGAD00001002136",
+            "title": "RNA sequencing data of Atypical teratoid/rhabdoid tumors (ATRT)",
+            "description": "RNA sequencing data of Atypical teratoid/rhabdoid tumors (ATRT)",
+            "type": [
+                "Transcriptome profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-18-05-2016-08:48:45:674-33"
+            ],
+            "creation_date": "2016-05-18T11:03.000Z",
+            "has_study": "EGAS00001001297"
+        },
+        {
+            "id": "EGAD00001002137",
+            "title": "WGBS data of Atypical teratoid/rhabdoid tumors (ATRT)",
+            "description": "WGBS data of Atypical teratoid/rhabdoid tumors (ATRT)",
+            "type": [
+                "Methylation profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-18-05-2016-08:53:46:927-34"
+            ],
+            "creation_date": "2016-05-18T11:03.000Z",
+            "has_study": "EGAS00001001297"
+        },
+        {
+            "id": "EGAD00001002138",
+            "title": "WGS data of Atypical teratoid/rhabdoid tumors (ATRT)",
+            "description": "WGS data of Atypical teratoid/rhabdoid tumors (ATRT)",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-IBIOS-18-05-2016-08:57:29:419-35"
+            ],
+            "creation_date": "2016-05-18T11:02.000Z",
+            "has_study": "EGAS00001001297"
+        },
+        {
+            "id": "EGAD00001002159",
+            "title": "Exome",
+            "description": "Exome Seq for Study EGAS00001001844",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-02-06-2016-16:14:01:314-131"
+            ],
+            "creation_date": "2016-06-07T13:11.000Z",
+            "has_study": "EGAS00001001844"
+        },
+        {
+            "id": "EGAD00001002160",
+            "title": "Exome",
+            "description": "Exome Seq for EGAS00001001845",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-02-06-2016-16:16:09:098-133"
+            ],
+            "creation_date": "2016-06-07T13:11.000Z",
+            "has_study": "EGAS00001001845"
+        },
+        {
+            "id": "EGAD00001002161",
+            "title": "Transcriptome",
+            "description": "Transcriptome from EGAS00001001845",
+            "type": [
+                "Transcriptome profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-02-06-2016-16:17:30:684-137"
+            ],
+            "creation_date": "2016-06-07T13:11.000Z",
+            "has_study": "EGAS00001001845"
+        },
+        {
+            "id": "EGAD00001002162",
+            "title": "Exome",
+            "description": "Exome Seq from EGAS00001001846",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-02-06-2016-16:18:51:312-138"
+            ],
+            "creation_date": "2016-06-07T13:11.000Z",
+            "has_study": "EGAS00001001846"
+        },
+        {
+            "id": "EGAD00001002163",
+            "title": "Transcriptome",
+            "description": "Transcriptome from EGAS00001001846",
+            "type": [
+                "Transcriptome profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-02-06-2016-16:19:57:504-139"
+            ],
+            "creation_date": "2016-06-07T13:10.000Z",
+            "has_study": "EGAS00001001846"
+        },
+        {
+            "id": "EGAD00001002164",
+            "title": "Exome",
+            "description": "Exome from EGA00001001848",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-02-06-2016-16:21:01:191-140"
+            ],
+            "creation_date": "2016-06-07T13:10.000Z",
+            "has_study": "EGAS00001001848"
+        },
+        {
+            "id": "EGAD00001002166",
+            "title": "Clear cell renal cell carcinoma (HIPO-045)",
+            "description": "Exome from EGAS00001001861",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-06-06-2016-09:38:03:185-52"
+            ],
+            "creation_date": "2016-06-06T07:05.000Z",
+            "has_study": "EGAS00001001861"
+        },
+        {
+            "id": "EGAD00001002528",
+            "title": "HIPO-P002 Whole genome",
+            "description": "WGS from EGAS00001001857",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-16-08-2016-09:06:02:030-345"
+            ],
+            "creation_date": "2016-08-16T07:07.000Z",
+            "has_study": "EGAS00001001857"
+        },
+        {
+            "id": "EGAD00001002695",
+            "title": "NeurOmics_HD_Modifier_V1",
+            "description": "48 samples from the TRACK-HD cohort. All samples carry the Huntington\u2019s disease expansion. The subjects were selected on the basis of rate of disease progression.",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000171",
+            "xref": [
+                "ena-DATASET-Neuromics-22-09-2016-08:49:06:149-211"
+            ],
+            "creation_date": "2016-09-22T06:10.000Z",
+            "has_study": "EGAS00001000698"
+        },
+        {
+            "id": "EGAD00001002699",
+            "title": "NeurOmics_HD_Biomarker-1_V1",
+            "description": "This data set includes RNAseq data from 136 samples from the TRACK-HD cohort including premanifest, manifest and control subjects. \nData can only be used for Huntington's disease related research.",
+            "type": [
+                "Transcriptome profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000171",
+            "xref": [
+                "ena-DATASET-Neuromics-22-09-2016-09:32:18:368-213"
+            ],
+            "creation_date": "2016-09-22T07:20.000Z",
+            "has_study": "EGAS00001000698"
+        },
+        {
+            "id": "EGAD00001003230",
+            "title": "Tumor-derived exosomes modulate PD-L1 expression in monocytes",
+            "description": "Small RNA expression profiles of the blood plasma-derived exosomes from B-cell chronic lymphocytic leukemia patients",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000221",
+            "xref": [
+                "Small RNA sequencing of blood plasma-derived exosomes from CLL"
+            ],
+            "creation_date": "2017-03-17T13:19.000Z",
+            "has_study": "EGAS00001002377"
+        },
+        {
+            "id": "EGAD00001003325",
+            "title": "Exome",
+            "description": "Exome from EGAS00001002441",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-09-05-2017-15:55:17:146-277"
+            ],
+            "creation_date": "2017-05-09T13:19.000Z",
+            "has_study": "EGAS00001002441"
+        },
+        {
+            "id": "EGAD00001003429",
+            "title": "RNA-Seq Pair End",
+            "description": "RNA analysis of two patients 11 and 15 with WGS done on Illumina HiSeq2000. For research purpose and authorised user only.",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000221",
+            "xref": [
+                "ena-DATASET-DKFZ-06-07-2017-16:10:50:154-493"
+            ],
+            "creation_date": "2017-07-06T14:53.000Z",
+            "has_study": "EGAS00001002270"
+        },
+        {
+            "id": "EGAD00001003430",
+            "title": "RNA-Seq Single End",
+            "description": "RNA analysis of six patients 34, 35, 36, 37, 38 and 39 with WGS done on Illumina HiSeq2500. For research purpose and authorised user only.",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000221",
+            "xref": [
+                "ena-DATASET-DKFZ-06-07-2017-17:03:52:162-505"
+            ],
+            "creation_date": "2017-07-06T15:54.000Z",
+            "has_study": "EGAS00001002270"
+        },
+        {
+            "id": "EGAD00001003436",
+            "title": "MiSeq-High Coverage",
+            "description": "Seven files of patients 3, 21, 29, 30, 31, 32 and 33 with WGS done on Illumina MiSeq with high coverage. For research purpose and authorised user only.",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000221",
+            "xref": [
+                "ena-DATASET-DKFZ-10-07-2017-14:51:26:287-19"
+            ],
+            "creation_date": "2017-07-10T12:29.000Z",
+            "has_study": "EGAS00001002270"
+        },
+        {
+            "id": "EGAD00001003437",
+            "title": "MiSeq-Low Coverage",
+            "description": "Fourteen files of patients 1, 2, 4, 6, 7, 8, 9, 12, 14, 16, 17, 18, 19 and 27 with WGS done on Illumina MiSeq with low coverage. For research purpose and authorised user only.",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000221",
+            "xref": [
+                "ena-DATASET-DKFZ-10-07-2017-14:56:28:042-20"
+            ],
+            "creation_date": "2017-07-10T12:30.000Z",
+            "has_study": "EGAS00001002270"
+        },
+        {
+            "id": "EGAD00001003438",
+            "title": "Illumina HiSeq 2000",
+            "description": "Three files of patients 20, 23 and 25  with WGS done on Illumina HiSeq 2000. For research purpose and authorised user only.",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000221",
+            "xref": [
+                "ena-DATASET-DKFZ-10-07-2017-15:00:31:755-21"
+            ],
+            "creation_date": "2017-07-10T13:33.000Z",
+            "has_study": "EGAS00001002270"
+        },
+        {
+            "id": "EGAD00001003439",
+            "title": "Illumina HiSeq X Ten",
+            "description": "Three files of patients 10, 11 and 13 with WGS done on Illumina HiSeq X Ten. For research purpose and authorised user only.",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000221",
+            "xref": [
+                "ena-DATASET-DKFZ-10-07-2017-15:01:36:723-22"
+            ],
+            "creation_date": "2017-07-10T13:38.000Z",
+            "has_study": "EGAS00001002270"
+        },
+        {
+            "id": "EGAD00001003440",
+            "title": "Patient 16CH",
+            "description": "One file of patient 16 with WGS done on Illumina HiSeq X-Ten. For research purpose and authorised user only.",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000221",
+            "xref": [
+                "ena-DATASET-DKFZ-10-07-2017-15:06:02:958-23"
+            ],
+            "creation_date": "2017-07-10T13:04.000Z",
+            "has_study": "EGAS00001002270"
+        },
+        {
+            "id": "EGAD00001003544",
+            "title": "Whole exome genome sequencing data to study \"A biobank of patient-derived pediatric brain tumor models\"",
+            "description": "Whole exome sequencing data to 30 PDOX models (28 early passages, 3 late passages (1 overlap)), 3 cell lines, and 20 matching human tumors",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000687",
+            "xref": [
+                "ena-DATASET-dkfz_b062-04-08-2017-13:47:34:208-1428"
+            ],
+            "creation_date": "2017-08-04T11:36.000Z",
+            "has_study": "EGAS00001002536"
+        },
+        {
+            "id": "EGAD00001003545",
+            "title": "Low-coverage whole genome sequencing data to study \"A biobank of patient-derived pediatric brain tumor models\"",
+            "description": "Low-coverage whole genome sequencing data for 30 PDOX models (28 early passages, 4 late passages (2 overlaps)), 3 cell lines, and 21 matching human tumors",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000687",
+            "xref": [
+                "ena-DATASET-dkfz_b062-04-08-2017-14:15:21:871-1439"
+            ],
+            "creation_date": "2017-08-04T12:23.000Z",
+            "has_study": "EGAS00001002536"
+        },
+        {
+            "id": "EGAD00001003573",
+            "title": "RNA sequencing data to study \"A biobank of patient-derived pediatric braintumor models\"",
+            "description": "RNA sequencing data for the PDOX model EPD-613FH",
+            "type": [
+                "Transcriptome profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000687",
+            "xref": [
+                "ena-DATASET-dkfz_b062-18-08-2017-15:54:03:183-161"
+            ],
+            "creation_date": "2017-08-18T13:04.000Z",
+            "has_study": "EGAS00001002536"
+        },
+        {
+            "id": "EGAD00001003827",
+            "title": "whole genome sequencing data of LMS cell lines",
+            "description": "The data set contains bam files aligned using bwa-0.7.8 mem -t 8 -R.",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-01-12-2017-12:36:36:554-60"
+            ],
+            "creation_date": "2017-12-01T11:38.000Z",
+            "has_study": "EGAS00001002437"
+        },
+        {
+            "id": "EGAD00001003828",
+            "title": "RNA-seq data of LMS tumors",
+            "description": "This dataset contains paired fastq files for LMS tumor samples",
+            "type": [
+                "Transcriptome profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-01-12-2017-13:02:22:609-63"
+            ],
+            "creation_date": "2017-12-01T12:24.000Z",
+            "has_study": "EGAS00001002437"
+        },
+        {
+            "id": "EGAD00001003829",
+            "title": "Exome sequencing data for LMS tumor and control samples",
+            "description": "The data set contains paired end fastq files for whole exome sequencing data for Leiomyosarcoma tumor and control samples",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-01-12-2017-13:14:23:391-67"
+            ],
+            "creation_date": "2017-12-01T12:25.000Z",
+            "has_study": "EGAS00001002437"
+        },
+        {
+            "id": "EGAD00001003940",
+            "title": "Whole genome sequencing data to study therapeutic targeting of ependymoma",
+            "description": "This dataset contains whole genome sequencing data from 24 patients. For each patient a tumour and control sample has been sequenced on a Illumina HiSeq2000 instrument in paired-end mode. Up to three lanes per sample have been sequenced resulting in 112 Fastq files.",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000221",
+            "xref": [
+                "ena-DATASET-dkfz_b062-31-01-2018-17:04:38:652-360"
+            ],
+            "creation_date": "2018-01-31T16:44.000Z",
+            "has_study": "EGAS00001002696"
+        },
+        {
+            "id": "EGAD00001003965",
+            "title": "Hipo-032 Metastasome of Colorectal Cancer",
+            "description": "Whole genome sequencing of Control (blood), Tumor and metastasis triplets for 12 samples.",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-16-02-2018-09:13:54:127-321"
+            ],
+            "creation_date": "2018-02-16T08:00.000Z",
+            "has_study": "EGAS00001002717"
+        },
+        {
+            "id": "EGAD00001003966",
+            "title": "RNA sequencing data to study therapeutic targeting of ependymoma",
+            "description": "This dataset conatains RNA sequencing data from 24 patients. Up to two lanes per tumour sample have been seqeunced on a Illumina HiSeq2000 instrument in paired-end mode resulting in 58 Fastq files.",
+            "type": [
+                "Transcriptome profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000221",
+            "xref": [
+                "ena-DATASET-dkfz_b062-16-02-2018-17:18:40:151-347"
+            ],
+            "creation_date": "2018-02-16T16:42.000Z",
+            "has_study": "EGAS00001002696"
+        },
+        {
+            "id": "EGAD00001003973",
+            "title": "Exome sequencing data to study therapeutic targeting of ependymoma",
+            "description": "This dataset contains whole exome sequencing data from 24 patients. The Agilent SureSelect Human All Exon 50-Mb target enrichment kit was used to capture all human exons for deep sequencing. For each patient a tumour and control sample has been sequenced on a Illumina HiSeq2000 instrument in paired-end mode. Up to three lanes per sample have been sequenced resulting in 118 Fastq files.",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000221",
+            "xref": [
+                "ena-DATASET-dkfz_b062-21-02-2018-14:40:33:479-591"
+            ],
+            "creation_date": "2018-02-21T13:35.000Z",
+            "has_study": "EGAS00001002696"
+        },
+        {
+            "id": "EGAD00001003979",
+            "title": "ChIP sequencing data to study therapeutic targeting of ependymoma",
+            "description": "This dataset contains ChIP sequencing data from 24 patients. ChIP of 5\u201310 mg flash-frozen primary ependymoma tumour was performed using 5 mg H3K27ac antibody per ChIP experiment. The enriched DNA has been sequenced on a Illumina HiSeq2000 instrument in paired-end mode. Up to two lanes per sample have been sequenced resulting in 70 Fastq files.",
+            "type": [
+                "Chip-Seq"
+            ],
+            "has_data_access_policy": "EGAP00001000221",
+            "xref": [
+                "ena-DATASET-dkfz_b062-23-02-2018-16:41:10:412-192"
+            ],
+            "creation_date": "2018-02-23T15:12.000Z",
+            "has_study": "EGAS00001002696"
+        },
+        {
+            "id": "EGAD00001004068",
+            "title": "Whole-genome, whole-exome and transcriptome sequencing of pancreatic ductal adenocarcinomas from young adults (NCT MASTER)",
+            "description": "Whole-genome, whole-exome and transcriptome sequencing of pancreatic ductal adenocarcinomas from young adults reveals recurrent NRG1-fusions in KRAS wild-type tumors.",
+            "type": [
+                "Whole genome sequencing",
+                "Exome sequencing",
+                "Transcriptome profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-06-04-2018-11:32:22:895-1684"
+            ],
+            "creation_date": "2018-04-06T09:24.000Z",
+            "has_study": "EGAS00001002759"
+        },
+        {
+            "id": "EGAD00001004132",
+            "title": "Variant Calling used in ABB project",
+            "description": "This dataset has two Variants Files in VCF format used in ABB project (https://github.com/Francesc-Muyas/ABB). \nOne has the variants found in a Rare Variant Association Study performed in CLL patients. This has 1217 samples represented. \nThe other variant file has 209 SNPs predicted in 10 samples by GATK HaplotypeCaller and selected for Sanger Sequencing Validation.\nRaw reads were aligned against the Human Reference genome (Hg19) with BWA mem and variants were obtained using GATK HaplotypeCaller.",
+            "type": [
+                "Exome sequencing",
+                "Genomic variant calling"
+            ],
+            "has_data_access_policy": "EGAP00001000889",
+            "xref": [
+                "2177fcf0-fe86-4de1-8a7b-02b67f71c3d5"
+            ],
+            "creation_date": "2018-05-25T12:52.000Z",
+            "has_study": "EGAS00001003027"
+        },
+        {
+            "id": "EGAD00001004313",
+            "title": "Amplicon sequencing data from organoids of colorectal cancer patients.",
+            "description": "The dataset includes 19 bam files. Each bam file is a different colorectal cancer patient organoid.",
+            "type": [
+                "Amplicon sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000962",
+            "xref": [
+                "c4c9db5f-364e-46c3-8cce-015b4d9b26a6"
+            ],
+            "creation_date": "2018-08-27T11:29.000Z",
+            "has_study": "EGAS00001003140"
+        },
+        {
+            "id": "EGAD00001004459",
+            "title": "WES of matched primary pediatric T-cell leukemias and PDXs",
+            "description": "Each dataset cosist of WES data from 5 samples (1 patient): original leukemia initial diagnosis T-ALL, original leukemia relapse T-ALL, PDX derived of initial diagnosis T-ALL, PDX derived of relapse T-ALL, remission (normal control)",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001001035",
+            "xref": [
+                "5cd543ac-f5b2-4d5f-b5db-e9357e087477"
+            ],
+            "creation_date": "2018-11-14T12:21.000Z",
+            "has_study": "EGAS00001003248"
+        },
+        {
+            "id": "EGAD00001004499",
+            "title": "Finding structural variation from the patient-derived xenografts of pediatric T-cell leukemia at the single-cell level",
+            "description": "In this study, we aimed to identify somatic structural variation of T-cell acute lymphoblastic leukemias (T-ALLs_ from patient-derived xenografts (PDX) at the single-cell level. For this purpose, we performed strand-specific single-cell sequencing of PDX-derived T-ALL relapse samples from two juvenile patients  (P1, P33). To validate structural variation detected via scTRIP, we profiled whole exome sequencing (WES) data from P33 (samples taken during initial disease, remission, relapse), and mate-pair sequencing data from P1 (relapse).",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001001056",
+            "xref": [
+                "ena-DATASET-EMBL-06-12-2018-02:10:51:685-261"
+            ],
+            "creation_date": "2018-12-06T01:56.000Z",
+            "has_study": "EGAS00001003365"
+        },
+        {
+            "id": "EGAD00001004563",
+            "title": "Whole genome sequencing of paired samples from primary and relapsed IDH-wt glioblastomas with matched blood controls",
+            "description": "This dataset contains whole genome sequencing data from 21 primary and relapsed IDH-wt glioblastomas and matched blood controls. Tumors were sequenced at a target coverage of 150x, blood controls at 80x.",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-16-01-2019-20:10:43:076-672"
+            ],
+            "creation_date": "2019-01-16T19:45.000Z",
+            "has_study": "EGAS00001003184"
+        },
+        {
+            "id": "EGAD00001004564",
+            "title": "Strand-specific RNA sequencing of 16 pairs of primary and relapsed IDH-wt glioblastomas",
+            "description": "This dataset contains strand-specific RNA sequencing data from 16 primary/relapsed sample pairs of IDH-wt glioblastomas",
+            "type": [
+                "Transcriptome profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-16-01-2019-20:19:26:486-673"
+            ],
+            "creation_date": "2019-01-16T19:28.000Z",
+            "has_study": "EGAS00001003184"
+        },
+        {
+            "id": "EGAD00001004565",
+            "title": "Gene panel sequencing of paired samples from primary and relapsed IDH-wt glioblastomas",
+            "description": "This dataset contains gene panel sequencing data from 43 sample pairs of primary and relapsed IDH-wt glioblastomas. The gene panel covers 50 glioma-associated genes. 14 of the sequenced sample pairs were sequenced with whole genome sequencing also and are accessible under EGAD00001004563.",
+            "type": [
+                "Amplicon sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "ena-DATASET-DKFZ-HIPO-16-01-2019-20:40:34:034-676"
+            ],
+            "creation_date": "2019-01-16T19:35.000Z",
+            "has_study": "EGAS00001003184"
+        },
+        {
+            "id": "EGAD00001004574",
+            "title": "Mannheim Liquid Biopsy Unit, Heidelberg University &amp; DKFZ",
+            "description": "The dataset consists of sequenced cell free DNA (cfDNA) samples from colorectal cancer patients. The samples were sequenced on an Illumina MiSeq machine using a custom amplicon sequencing approach. These amplicons were designed to cover the most common mutation hotspots in colorectal cancer. The data include 138 cfDNA samples from 34 different patients. For each patient several samples are available derived from blood drawn at different time points during treatment. In addition the data include samples from 22 histology slides and 30 samples derived from HT29/HCT116 cell lines that were used as controls.",
+            "type": [
+                "Amplicon sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001001086",
+            "xref": [
+                "7d1d07e0-94fe-49b9-8055-92660cffd053"
+            ],
+            "creation_date": "2019-01-21T09:11.000Z",
+            "has_study": "EGAS00001003382"
+        },
+        {
+            "id": "EGAD00001004825",
+            "title": "24 Chordoma samples (WES,WGS)",
+            "description": "Case series of the rare tumor entity chordoma. 9 cases sequenced with Whole Exome Sequencing (WES) and 2 cases sequenced with Whole Genome Sequencing (WGS) were recruited from the personalized oncology program NCT-MASTER/DKTK-MASTER at the German Cancer Research Center. One of the WES patients was re-sequenced at a later time point when he relapsed, this resequencing was done by WGS. Therefore there are 11 patients, one of which with two samples, all of which were sequenced with matched normal controls, amounting to a total number of 24 NGS samples.",
+            "type": [
+                "Whole genome sequencing",
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "7687436a-e704-42d8-b3c9-ab87e961e2e0"
+            ],
+            "creation_date": "2019-03-06T11:09.000Z",
+            "has_study": "EGAS00001002720"
+        },
+        {
+            "id": "EGAD00001004887",
+            "title": "Exome sequencing of matching primary tumor and venous tumor thrombus (VTT) renal cell carcinoma (RCC) samples",
+            "description": "We performed multiregion whole exome sequencing of a total of 37 samples from five consecutive patients (normal tissue, n=5; primary tumors, n=16; tumor thrombi, n=16) to &gt;35-fold target coverage. Matching primary tumor and venous tumor thrombus samples were analyzed. Four patients had a clear cell RCC, one patient had a poorly differentiated type II papillary RCC (RCC-VTT-04). The latter patient had a friable thrombus, the others were of solid consistency.",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000456",
+            "xref": [
+                "faa1d2f2-265c-462c-aff3-94cc4b356a90"
+            ],
+            "creation_date": "2019-04-03T10:56.000Z",
+            "has_study": "EGAS00001001950"
+        },
+        {
+            "id": "EGAD00001005021",
+            "title": "ChIPseq Sequencing data for epigenetic subgroups of meningioma",
+            "description": "Bam files for 16 meningioma tumor samples; ChIPseq performed on Illumina HiSeq 2000",
+            "type": [
+                "Chip-Seq"
+            ],
+            "has_data_access_policy": "EGAP00001000687",
+            "xref": [
+                "bc246e56-19ea-4c30-9e33-160ac12c3050"
+            ],
+            "creation_date": "2019-05-15T11:35.000Z",
+            "has_study": "EGAS00001003481"
+        },
+        {
+            "id": "EGAD00001005061",
+            "title": "Whole Genome Sequencing data for epigenetic subgroups of meningioma",
+            "description": "Bam files for 124 samples (62 tumor vs blood pairs); Whole Genome Sequencing performed on Illumina HiSeq X Ten",
+            "type": [
+                "Whole genome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "be40ebac-acee-4026-a661-4330bb0f657b"
+            ],
+            "creation_date": "2019-06-04T09:40.000Z",
+            "has_study": "EGAS00001003481"
+        },
+        {
+            "id": "EGAD00001005113",
+            "title": "EGAS00001003405 combined RNA, WES, WGS data of 16 gastrointestinal tumor patients",
+            "description": "50 samples of 16 individuals with Gastrointestinal Tumor. Patients were sequenced in various combinations of WGS, Exome and RNA sequencing.",
+            "type": [
+                "Whole genome sequencing",
+                "Exome sequencing",
+                "Transcriptome profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "69ab3410-fe23-42b3-a34e-a7f83ab902d8"
+            ],
+            "creation_date": "2019-06-27T11:29.000Z",
+            "has_study": "EGAS00001003405"
+        },
+        {
+            "id": "EGAD00001005249",
+            "title": "Exome and RNA seq data for female patient",
+            "description": "Exome and RNA sequencing data for EGAS00001003776 - one female patient with neurofibroma/schwannoma hybrid nerve sheath tumor (N/S HNST)",
+            "type": [
+                "Exome sequencing",
+                "Transcriptome profiling by high-throughput sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "c8abf99f-5f5a-46f4-b0a5-ba5d5dcf72ad"
+            ],
+            "creation_date": "2019-08-13T13:48.000Z",
+            "has_study": "EGAS00001003776"
+        },
+        {
+            "id": "EGAD00001005370",
+            "title": "WES from two human osteosarcoma with two samples each from the corresponding cell line",
+            "description": "WES from two human osteosarcoma with two samples each from the corresponding cell line, BAM files",
+            "type": [
+                "Exome sequencing"
+            ],
+            "has_data_access_policy": "EGAP00001001314",
+            "xref": [
+                "164a2fdc-6bef-418c-82a7-2f24fd2a1bbf"
+            ],
+            "creation_date": "2019-10-02T05:23.000Z",
+            "has_study": "EGAS00001003923"
+        },
+        {
+            "id": "EGAD00010000947",
+            "title": "Gencode_15K",
+            "description": "Lymphoma samples using CytoSNP",
+            "type": [
+                "sample"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "Gencode_15K"
+            ],
+            "creation_date": "2016-07-08T12:55.000Z",
+            "has_study": "EGAS00001001746"
+        },
+        {
+            "id": "EGAD00010000948",
+            "title": "Gencode_500K",
+            "description": "Lymphoma samples using 450k",
+            "type": [
+                "sample"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "Gencode_500K"
+            ],
+            "creation_date": "2016-07-08T12:55.000Z",
+            "has_study": "EGAS00001001746"
+        },
+        {
+            "id": "EGAD00010000949",
+            "title": "Gencode_550K",
+            "description": "Lymphoma samples using HumanOmni",
+            "type": [
+                "sample"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "Gencode_550K"
+            ],
+            "creation_date": "2016-07-08T12:55.000Z",
+            "has_study": "EGAS00001001746"
+        },
+        {
+            "id": "EGAD00010001001",
+            "title": "Illumina_450K",
+            "description": "Primary renal cell carcinoma (RCC), RCC metastases and cell lines by Illumina 450K",
+            "type": [
+                "sample"
+            ],
+            "has_data_access_policy": "EGAP00001000506",
+            "xref": [
+                "Illumina_450K"
+            ],
+            "creation_date": "2016-08-19T07:41.000Z",
+            "has_study": "EGAS00001001176"
+        },
+        {
+            "id": "EGAD00010001564",
+            "title": "Affymetrix_miRNA4.0",
+            "description": "Primary renal cell carcinoma (RCC) by Affymetrix GeneChip miRNA 4.0",
+            "type": [
+                "sample"
+            ],
+            "has_data_access_policy": "EGAP00001000506",
+            "xref": [
+                "Affymetrix_miRNA4.0"
+            ],
+            "creation_date": "2018-05-16T13:51.000Z",
+            "has_study": "EGAS00001001176"
+        },
+        {
+            "id": "EGAD00010001589",
+            "title": "Affymetrix_HTA2.0",
+            "description": "Primary renal cell carcinoma (RCC) and RCC metastases by Affymetrix GeneChip HTA 2.0",
+            "type": [
+                "sample"
+            ],
+            "has_data_access_policy": "EGAP00001000506",
+            "xref": [
+                "Affymetrix_HTA2.0"
+            ],
+            "creation_date": "2018-07-28T14:00.000Z",
+            "has_study": "EGAS00001001176"
+        },
+        {
+            "id": "EGAD00010001642",
+            "title": "EPIC DNA Methylation Array",
+            "description": "",
+            "type": [
+                "sample"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "EPIC DNA Methylation Array"
+            ],
+            "creation_date": "2018-12-12T13:26.000Z",
+            "has_study": "EGAS00001003184"
+        },
+        {
+            "id": "EGAD00010001643",
+            "title": "450k DNA Methylation Array",
+            "description": "",
+            "type": [
+                "sample"
+            ],
+            "has_data_access_policy": "EGAP00001000441",
+            "xref": [
+                "450k DNA Methylation Array"
+            ],
+            "creation_date": "2018-12-12T13:26.000Z",
+            "has_study": "EGAS00001003184"
+        }
+    ]
+}

--- a/ega-examples/transformed/members.json
+++ b/ega-examples/transformed/members.json
@@ -1,0 +1,165 @@
+{
+    "members": [
+        {
+            "id": "bacb9d66-9ce4-4e42-a813-e7efad374aa0",
+            "name": "Birte Zurek",
+            "email": "birte.zurek@med.uni-tuebingen.de",
+            "telephone": "+4970712972285",
+            "organization": "University of Tuebingen Institute of Medical Genetics and Applied Genomics"
+        },
+        {
+            "id": "8b913ce3-cc0d-4054-887c-96dc5799672a",
+            "name": "DKTK DAC",
+            "email": "daco-dkfz-b06x@dkfz-heidelberg.de",
+            "telephone": null,
+            "organization": "German Cancer Research Center (DKFZ)"
+        },
+        {
+            "id": "d7fa32ad-b40a-40e0-a09a-1ece5bd81168",
+            "name": "DACO B060x",
+            "email": "daco-dkfz-b06x@dkfz-heidelberg.de",
+            "telephone": null,
+            "organization": "German Cancer Research Center (DKFZ)"
+        },
+        {
+            "id": "a47cf387-fb28-48f4-91e7-faa1f18cf55f",
+            "name": "Matthias Schwab",
+            "email": "matthias.schwab@ikp-stuttgart.de",
+            "telephone": null,
+            "organization": "Dr Margarete Fischer-Bosch-Institute of Clinical Pharmacology, Stuttgart, Germany"
+        },
+        {
+            "id": "61663b14-c89c-440b-83e6-eb8eb1266335",
+            "name": "Elke Sch\u00e4ffeler",
+            "email": "elke.schaeffeler@ikp-stuttgart.de",
+            "telephone": null,
+            "organization": "Dr Margarete Fischer-Bosch-Institute of Clinical Pharmacology, Stuttgart, Germany"
+        },
+        {
+            "id": "9b92856a-4de2-4917-8014-0053ae8e15fd",
+            "name": "Jens Bedke",
+            "email": "jens.bedke@med.uni-tuebingen.de",
+            "telephone": null,
+            "organization": "Department of Urology, University Hospital Tuebingen, Tuebingen, Germany"
+        },
+        {
+            "id": "5208692b-3143-4288-91a4-692210b4d987",
+            "name": "Florian B\u00fcttner",
+            "email": "florian.buettner@ikp-stuttgart.de",
+            "telephone": null,
+            "organization": "Dr Margarete Fischer-Bosch-Institute of Clinical Pharmacology, Stuttgart, Germany"
+        },
+        {
+            "id": "c4b8000a-e53f-4f20-a878-7e11ecae2721",
+            "name": "Stefan Winter",
+            "email": "stefan.winter@ikp-stuttgart.de",
+            "telephone": null,
+            "organization": "Dr Margarete Fischer-Bosch-Institute of Clinical Pharmacology, Stuttgart, Germany"
+        },
+        {
+            "id": "a5fd9de8-8e0d-477b-9c94-7d1ead6d8ec8",
+            "name": "Arnulf Stenzl",
+            "email": "arnulf.stenzl@med.uni-tuebingen.de",
+            "telephone": null,
+            "organization": "Department of Urology, University Hospital Tuebingen, Tuebingen, Germany"
+        },
+        {
+            "id": "01f42268-6a4a-4526-ad65-ed75098c328e",
+            "name": "Dr. Matthias Schlesner",
+            "email": "m.schlesner@dkfz-heidelberg.de",
+            "telephone": null,
+            "organization": "German Cancer Research Center (DKFZ)"
+        },
+        {
+            "id": "a0b45b03-3cfe-48b3-96a4-beae68ed09c9",
+            "name": "Omics &amp; Datamanagment Core Facility",
+            "email": "odcf-service@dkfz-heidelberg.de",
+            "telephone": null,
+            "organization": "German Cancer Research Center (DKFZ)"
+        },
+        {
+            "id": "427410eb-1dd2-4068-8491-59a42ef8e4f0",
+            "name": "Katja Beck",
+            "email": "hipo_daco@dkfz-heidelberg.de",
+            "telephone": null,
+            "organization": "German Cancer Research Center (DKFZ)"
+        },
+        {
+            "id": "7d7816cb-083b-428c-9395-4f1e66ecec13",
+            "name": "Stefan Duensing",
+            "email": "stefan.duensing@med.uni-heidelberg.de",
+            "telephone": "+496221566255",
+            "organization": "University of Heidelberg"
+        },
+        {
+            "id": "7e2e718f-69ee-453e-8856-c51e187e5683",
+            "name": "Stephan Ossowski",
+            "email": "stephan.ossowski@med.uni-tuebingen.de",
+            "telephone": "070712972323",
+            "organization": "Institute of Medical Genetics and Applied Genomics - Universit\u00e4t Klinikum T\u00fcbingen "
+        },
+        {
+            "id": "21209b42-7ec4-49df-9d36-39bc68187bbb",
+            "name": "Boutros, Prof. Dr. Michael",
+            "email": "m.boutros@dkfz-heidelberg.de",
+            "telephone": "00496221421951",
+            "organization": "Deutsches Krebsforschungszentrum DKFZ"
+        },
+        {
+            "id": "dde9978d-d09c-4aa9-baf1-ff8ee76f9281",
+            "name": "Ebert, Prof. Dr. Matthias",
+            "email": "matthias.ebert@medma.uni-heidelberg.de",
+            "telephone": "00496213833284",
+            "organization": "Universit\u00e4tsmedizin Mannheim"
+        },
+        {
+            "id": "40428387-b0ac-4403-a372-5be36a9832f1",
+            "name": "Betge, Dr. Johannes",
+            "email": "j.betge@dkfz-heidelberg.de",
+            "telephone": "00496221421957",
+            "organization": "Deutsches Krebsforschungszentrum DKFZ"
+        },
+        {
+            "id": "259b245c-b0bb-4492-a795-3ef4542945f2",
+            "name": "Paulina Richter-Pechanska",
+            "email": "paulina.richter-pechanska@med.uni-heidelberg.de",
+            "telephone": "+496221564579",
+            "organization": "University Hospital in Heidelberg, Germany"
+        },
+        {
+            "id": "155cced9-62e5-43e4-82c6-2150f06ed010",
+            "name": "Andreas Kulozik",
+            "email": "andreas.kulozik@med.uni-heidelberg.de",
+            "telephone": "+496221564500",
+            "organization": "University of Heidelberg"
+        },
+        {
+            "id": "7c26647d-a53a-412b-8986-2e56dec526b4",
+            "name": "Jan Korbel",
+            "email": "korbel@embl.de",
+            "telephone": "+4962213878822",
+            "organization": "European Molecular Biology Laboratory (EMBL)"
+        },
+        {
+            "id": "967aa4f2-d5ac-4bd6-92e6-82d7ff375d36",
+            "name": "Matthias Ebert",
+            "email": "matthias.ebert@medma.uni-heidelberg.de",
+            "telephone": "+496213833284",
+            "organization": "Heidelberg University"
+        },
+        {
+            "id": "0781d9f1-1330-4bf0-85b1-df5ffc7e53c6",
+            "name": "Michael Boutros",
+            "email": "m.boutros@dkfz.de",
+            "telephone": "+496221421950",
+            "organization": "German Cancer Research Center (DKFZ)"
+        },
+        {
+            "id": "2bb3e559-2eb7-4a94-b507-b77bd2efd3cb",
+            "name": "Eva Kathrin Roth",
+            "email": "eva.roth@med.uni-heidelberg.de",
+            "telephone": "+4962215636967",
+            "organization": "Department of Pediatric Oncology, Hematology and Immunology and Hopp Children\u2019s Cancer Center at the NCT Heidelberg (KiTZ), University of Heidelberg, Heidelberg, Germany\u2028"
+        }
+    ]
+}

--- a/ega-examples/transformed/studies.json
+++ b/ega-examples/transformed/studies.json
@@ -1,0 +1,617 @@
+{
+    "studies": [
+        {
+            "id": "EGAS00001000274",
+            "title": "Coverage bias and sensitivity of variant calling for four whole-genome sequencing technologies",
+            "description": "Massively parallel sequencing has revolutionized research in cancer genetics and genomics and enhanced our understanding of natural human genetic variation. Recently, Lam et al. have performed a detailed comparison of two next-generation sequencing technologies with respect to their sensitivity to call single nucleotide variants (SNV) and indels. Here, we sequenced two tumor/normal pairs obtained from two paedriatic medulloblastoma patients with Life Technologies\u2019 SOLiD 4 and 5500xl SOLiD, Illumina\u2019s HiSeq2000, and Complete Genomics\u2019 technology.  We then compared their ability to call SNVs with high confidence. As gold standard for SNV calling, we used genotypes determined by an Affymetrix SNP array. Additionally, we performed a detailed analysis of how evenly each technology covers the genome and how the reads are distributed across functional genomic regions. Finally, we studied how a combination of data from different technologies might help to overcome the limitations in SNV calling by any of the four technologies alone.",
+            "abstract": "Massively parallel sequencing has revolutionized research in cancer genetics and genomics and enhanced our understanding of natural human genetic variation. Recently, Lam et al. have performed a detailed comparison of two next-generation sequencing technologies with respect to their sensitivity to call single nucleotide variants (SNV) and indels. Here, we sequenced two tumor/normal pairs obtained from two paedriatic medulloblastoma patients with Life Technologies\u2019 SOLiD 4 and 5500xl SOLiD, Illumina\u2019s HiSeq2000, and Complete Genomics\u2019 technology.  We then compared their ability to call SNVs with high confidence. As gold standard for SNV calling, we used genotypes determined by an Affymetrix SNP array. Additionally, we performed a detailed analysis of how evenly each technology covers the genome and how the reads are distributed across functional genomic regions. Finally, we studied how a combination of data from different technologies might help to overcome the limitations in SNV calling by any of the four technologies alone.",
+            "type": "Whole Genome Sequencing",
+            "has_dataset": [
+                "EGAD00001000174"
+            ],
+            "xref": [
+                "Coverage_bias_sensitivity_of_variant_calling_for_4_WG_seq_tech"
+            ],
+            "creation_date": "2012-04-23T07:13.000Z"
+        },
+        {
+            "id": "EGAS00001000443",
+            "title": "Epigenomic alterations define lethal CIMP-positive ependymomas of infancy",
+            "description": "Ependymomas are common childhood brain tumours that occur throughout the nervous system, but are most common in the paediatric hindbrain. Current standard therapy comprises surgery and radiation, but not cytotoxic chemotherapy as it does not further increase survival. Whole-genome and whole-exome sequencing of 47 hindbrain ependymomas reveals an extremely low mutation rate, and zero significant recurrent somatic single nucleotide variants. Although devoid of recurrent single nucleotide variants and focal copy number aberrations, poor-prognosis hindbrain ependymomas exhibit a CpG island methylator phenotype. Transcriptional silencing driven by CpG methylation converges exclusively on targets of the Polycomb repressive complex 2 which represses expression of differentiation genes through trimethylation of H3K27. CpG island methylator phenotype-positive hindbrain ependymomas are responsive to clinical drugs that target either DNA or H3K27 methylation both in vitro and in vivo. We conclude that epigenetic modifiers are the first rational therapeutic candidates for this deadly malignancy, which is epigenetically deregulated but genetically bland.",
+            "abstract": "Ependymomas are common childhood brain tumours that occur throughout the nervous system, but are most common in the paediatric hindbrain. Current standard therapy comprises surgery and radiation, but not cytotoxic chemotherapy as it does not further increase survival. Whole-genome and whole-exome sequencing of 47 hindbrain ependymomas reveals an extremely low mutation rate, and zero significant recurrent somatic single nucleotide variants. Although devoid of recurrent single nucleotide variants and focal copy number aberrations, poor-prognosis hindbrain ependymomas exhibit a CpG island methylator phenotype. Transcriptional silencing driven by CpG methylation converges exclusively on targets of the Polycomb repressive complex 2 which represses expression of differentiation genes through trimethylation of H3K27. CpG island methylator phenotype-positive hindbrain ependymomas are responsive to clinical drugs that target either DNA or H3K27 methylation both in vitro and in vivo. We conclude that epigenetic modifiers are the first rational therapeutic candidates for this deadly malignancy, which is epigenetically deregulated but genetically bland.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001000966"
+            ],
+            "xref": [
+                "lindt_ependymoma_2013_02_28"
+            ],
+            "creation_date": "2013-02-28T11:24.000Z"
+        },
+        {
+            "id": "EGAS00001000455",
+            "title": "Whole genome bisufite sequencing of smoking and non-smoking mother-child pairsBisufite sequencing, RNA-seq and ChIP-Seq data of whole blood samples from smoking and non-smoking mothers and their children at gestation/birth and follow-up years.",
+            "description": "Whole-blood samples of 16 mother-child pairs with differing maternal smoking behaviour were bisulfite treated and sequenced with deep coverage to identify smoking-associated differentially methylated regions.RNA-sequencing and ChIP-sequencing of 4 chromatin marks complete the data set and allow for integrative analyses, functional region annotation and to study the impact of epigenetic changes on gene expression.Longitudinal data spanning several years provides the means to investigate the stability of observed differences of all data types.",
+            "abstract": "Whole-blood samples of 16 mother-child pairs with differing maternal smoking behaviour were bisulfite treated and sequenced with deep coverage to identify smoking-associated differentially methylated regions.RNA-sequencing and ChIP-sequencing of 4 chromatin marks complete the data set and allow for integrative analyses, functional region annotation and to study the impact of epigenetic changes on gene expression.Longitudinal data spanning several years provides the means to investigate the stability of observed differences of all data types.",
+            "type": "Epigenetics",
+            "has_dataset": [
+                "EGAD00001000366",
+                "EGAD00001002011",
+                "EGAD00001002012"
+            ],
+            "xref": [
+                "marlboro-EEP-2013-03-15"
+            ],
+            "creation_date": "2013-03-15T12:31.000Z"
+        },
+        {
+            "id": "EGAS00001000698",
+            "title": "Neuromics / RD-Connect - Huntington's disease",
+            "description": "This study contains omics datasets from the Neuromics project (www.rd-neuromics.eu) on rare neuromuscular and neurodegenerative disorders.   Data includes BAM and VCF files from whole-exome sequencing and standardised phenotypic data mapped to the human phenotype ontology (HPO). In some cases proteomic, transcriptomic and metabolomic data may also be available.  This study groups together datasets from individuals with a Huntington's disease phenotype and also includes some unaffected family members. Search under the Neuromics name to find related studies for other neuromuscular and neurodegenerative disorders.",
+            "abstract": "This study contains omics datasets from the Neuromics project (www.rd-neuromics.eu) on rare neuromuscular and neurodegenerative disorders.   Data includes BAM and VCF files from whole-exome sequencing and standardised phenotypic data mapped to the human phenotype ontology (HPO). In some cases proteomic, transcriptomic and metabolomic data may also be available.  This study groups together datasets from individuals with a Huntington's disease phenotype and also includes some unaffected family members. Search under the Neuromics name to find related studies for other neuromuscular and neurodegenerative disorders.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001002695",
+                "EGAD00001002699"
+            ],
+            "xref": [
+                "ena-STUDY-NEUROMICS-06-02-2014-22:55:01:287-32"
+            ],
+            "creation_date": "2014-02-06T21:11.000Z"
+        },
+        {
+            "id": "EGAS00001000767",
+            "title": "Next generation sequencing of sporadic schwannomatosis samples",
+            "description": "Schwannomatosis (MIM #162091) is characterized by the development of multiple schwannomas without vestibular nerve involvement (which is a characteristic of neurofibromatosis type 2 - NF2). In an effort to detect novel genetic alterations predisposing to schwannomatosis, we sequenced eight tumor-blood DNA pairs from de novo schwannomatosis patients. The results of our study are present in the paper \"Whole exome sequencing reveals that the majority of schwannomatosis cases remain unexplained after excluding SMARCB1 and LZTR1 germline variants\" published in Acta Neuropathologica (PMID:25008767)",
+            "abstract": "Schwannomatosis (MIM #162091) is characterized by the development of multiple schwannomas without vestibular nerve involvement (which is a characteristic of neurofibromatosis type 2 - NF2). In an effort to detect novel genetic alterations predisposing to schwannomatosis, we sequenced eight tumor-blood DNA pairs from de novo schwannomatosis patients. The results of our study are present in the paper \"Whole exome sequencing reveals that the majority of schwannomatosis cases remain unexplained after excluding SMARCB1 and LZTR1 germline variants\" published in Acta Neuropathologica (PMID:25008767)",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001000963",
+                "EGAD00001000964"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-IBIOS-11-04-2014-11:44:21:184-48"
+            ],
+            "creation_date": "2014-04-11T09:28.000Z"
+        },
+        {
+            "id": "EGAS00001000882",
+            "title": "Succession Of Transiently Active Tumour-Initiating Cell Clones inHuman Pancreatic Cancer",
+            "description": "To elucidate whether newly acquired genetic alterations during serial transplantation of patient derived primary pancreatic cancer cultures contribute to the observed clonal dynamics in vivo, all coding genes of two  patient derived primary cultures and derived genetically marked serial xenografts (1\u00b0/2\u00b0/3\u00b0) were sequenced.",
+            "abstract": "To elucidate whether newly acquired genetic alterations during serial transplantation of patient derived primary pancreatic cancer cultures contribute to the observed clonal dynamics in vivo, all coding genes of two  patient derived primary cultures and derived genetically marked serial xenografts (1\u00b0/2\u00b0/3\u00b0) were sequenced.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001000884"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-IBIOS-07-07-2014-11:44:41:912-82"
+            ],
+            "creation_date": "2014-07-07T09:47.000Z"
+        },
+        {
+            "id": "EGAS00001000906",
+            "title": "Mutations in the SIX1/2 pathway and the DROSHA/DGCR8 miRNA microprocessor complex underlie high-risk blastemal type Wilms tumors",
+            "description": "Blastemal histology in chemotherapy-treated pediatric Wilms tumors (nephroblastoma) is associated with adverse prognosis. In order to find novel therapeutic leads for this subgroup of patients, we analyzed 58 such Wilms tumors by exome and transcriptome analysis and validated our findings in larger independent cohorts. Recurrent mutations identified either somatically or in the germline included a hotspot mutation (Q177R) in the homeodomain of SIX1 and SIX2 in tumors with high proliferative potential, mutations in microprocessor genes like DROSHA, DGCR8, DICER1 and DIS3L2, and alterations in IGF2, MYCN, and TP53, the latter being strongly associated with dismal outcome. DROSHA and DGCR8 mutations had a strong effect on miRNA profiles in tumors, which we confirmed in cell lines transfected with mutant DROSHA.",
+            "abstract": "Blastemal histology in chemotherapy-treated pediatric Wilms tumors (nephroblastoma) is associated with adverse prognosis. In order to find novel therapeutic leads for this subgroup of patients, we analyzed 58 such Wilms tumors by exome and transcriptome analysis and validated our findings in larger independent cohorts. Recurrent mutations identified either somatically or in the germline included a hotspot mutation (Q177R) in the homeodomain of SIX1 and SIX2 in tumors with high proliferative potential, mutations in microprocessor genes like DROSHA, DGCR8, DICER1 and DIS3L2, and alterations in IGF2, MYCN, and TP53, the latter being strongly associated with dismal outcome. DROSHA and DGCR8 mutations had a strong effect on miRNA profiles in tumors, which we confirmed in cell lines transfected with mutant DROSHA.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001000992",
+                "EGAD00001000993",
+                "EGAD00001000994",
+                "EGAD00001000995"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-IBIOS-28-07-2014-14:03:57:377-342"
+            ],
+            "creation_date": "2014-07-28T12:08.000Z"
+        },
+        {
+            "id": "EGAS00001000948",
+            "title": "DKFZ-HIPO Project H021/NCT MASTER",
+            "description": "Clinical genome and transcriptome sequencing in younger adults with advanced-stage cancer across all histologies: DKFZ-HIPO Project H021 (http://www.hipo-heidelberg.org/hipo2/index.php/menu-item-2/32-021-prospective-genetic-characterization-of-tumors-from-individual-patients-of-special-interest) / NCT MASTER (http://www.nct-heidelberg.de/forschung/nct-master.html)",
+            "abstract": "Clinical genome and transcriptome sequencing in younger adults with advanced-stage cancer across all histologies: DKFZ-HIPO Project H021 (http://www.hipo-heidelberg.org/hipo2/index.php/menu-item-2/32-021-prospective-genetic-characterization-of-tumors-from-individual-patients-of-special-interest) / NCT MASTER (http://www.nct-heidelberg.de/forschung/nct-master.html)",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001000997",
+                "EGAD00001001384"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-IBIOS-26-08-2014-12:22:47:124-866"
+            ],
+            "creation_date": "2014-08-26T10:00.000Z"
+        },
+        {
+            "id": "EGAS00001001176",
+            "title": "Study of renal cancers and renal cancer metastases",
+            "description": "Study of primary renal cancers as well as metastases derived from renal cancers in various distant organs.",
+            "abstract": "Study of primary renal cancers as well as metastases derived from renal cancers in various distant organs.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00010001001",
+                "EGAD00010001564",
+                "EGAD00010001589"
+            ],
+            "xref": [
+                "ena-STUDY-TUSCO-27-02-2015-17:06:14:403-294"
+            ],
+            "creation_date": "2015-02-27T16:26.000Z"
+        },
+        {
+            "id": "EGAS00001001199",
+            "title": "MINCR is a MYC-induced lncRNA able to modulate MYC\u2019s transcriptional network in Burkitt lymphoma cells",
+            "description": "Despite the established role of the transcription factor MYC in cancer, little is known about the involvement of lncRNAs in mediating MYC\u2019s function. Here we have intersected RNA-sequencing data from MYC-inducible cell lines, from a cohort of 91 mature B-cell lymphomas and from sorted germinal-center B-cells. By this approach, we identified 13 lncRNAs differentially expressed in IG-MYC-positive Burkitt lymphoma and regulated by MYC in the model cell lines. Among them we focused on a lncRNA that we named MINCR, showing a strong correlation with MYC expression in MYC-positive lymphomas and in pancreatic ductal adenocarcinomas. RNAi experiments showed that MINCR controls cellular viability by influencing the expression of MYC-regulated cell cycle genes. Finally we provide evidences that down-regulation of AURKA, AURKB and CTD1 may explain the reduction in cellular proliferation observed upon MINCR knock-down. We therefore suggest that MINCR acts as a modulator of MYC transcriptional control of cell cycle genes.",
+            "abstract": "Despite the established role of the transcription factor MYC in cancer, little is known about the involvement of lncRNAs in mediating MYC\u2019s function. Here we have intersected RNA-sequencing data from MYC-inducible cell lines, from a cohort of 91 mature B-cell lymphomas and from sorted germinal-center B-cells. By this approach, we identified 13 lncRNAs differentially expressed in IG-MYC-positive Burkitt lymphoma and regulated by MYC in the model cell lines. Among them we focused on a lncRNA that we named MINCR, showing a strong correlation with MYC expression in MYC-positive lymphomas and in pancreatic ductal adenocarcinomas. RNAi experiments showed that MINCR controls cellular viability by influencing the expression of MYC-regulated cell cycle genes. Finally we provide evidences that down-regulation of AURKA, AURKB and CTD1 may explain the reduction in cellular proliferation observed upon MINCR knock-down. We therefore suggest that MINCR acts as a modulator of MYC transcriptional control of cell cycle genes.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001001598"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-IBIOS-20-03-2015-12:32:08:389-558"
+            ],
+            "creation_date": "2015-03-20T11:23.000Z"
+        },
+        {
+            "id": "EGAS00001001252",
+            "title": "Engineering of a promoterless anti-viral RNAi hairpin into an endogenous miRNA locus",
+            "description": "Short hairpin RNA (shRNA) expression strategies that allow safe and persistent target mRNA knockdown are key to the success of many in vitro or in vivo RNAi applications. Here, we propose a novel solution which is expression of a promoterless miRNA-adapted shRNA (shmiRNA) from an engineered genomic miRNA locus. For proof-of-concept, we genetically \u201cvaccinated\u201d liver cells against a human pathogen, by using TALEns or CRISPR to integrate an anti-hepatitis C virus (HCV) shmiRNA into the liver-specific miR-122/hcr gene. Reporter assays and qRT-PCR confirmed anti-HCV shmiRNA expression as well as miR-122 integrity and functionality. Specificity and safety of shmiRNA integration were validated via PCR, cDNA and miRNA profiling, and whole genome sequencing. A subgenomic HCV replicon and a full-length reporter virus, but not a Dengue virus control, were significantly impaired in the modified cells. Our original combination of DNA engineering and RNAi expression technologies should benefit numerous applications, from basic miRNA research, to human cell and gene therapy.",
+            "abstract": "Short hairpin RNA (shRNA) expression strategies that allow safe and persistent target mRNA knockdown are key to the success of many in vitro or in vivo RNAi applications. Here, we propose a novel solution which is expression of a promoterless miRNA-adapted shRNA (shmiRNA) from an engineered genomic miRNA locus. For proof-of-concept, we genetically \u201cvaccinated\u201d liver cells against a human pathogen, by using TALEns or CRISPR to integrate an anti-hepatitis C virus (HCV) shmiRNA into the liver-specific miR-122/hcr gene. Reporter assays and qRT-PCR confirmed anti-HCV shmiRNA expression as well as miR-122 integrity and functionality. Specificity and safety of shmiRNA integration were validated via PCR, cDNA and miRNA profiling, and whole genome sequencing. A subgenomic HCV replicon and a full-length reporter virus, but not a Dengue virus control, were significantly impaired in the modified cells. Our original combination of DNA engineering and RNAi expression technologies should benefit numerous applications, from basic miRNA research, to human cell and gene therapy.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001001386"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-IBIOS-11-05-2015-14:22:15:176-132"
+            ],
+            "creation_date": "2015-05-11T12:28.000Z"
+        },
+        {
+            "id": "EGAS00001001297",
+            "title": "Comprehensive analysis of the (epi)genome of pediatric atypical teratoid/rhabdoid tumours (AT/RTs)",
+            "description": "Whole exome sequencing of atypical teratoid /rhabdoid tumors (AT/RTs) revealed recurrent mutations only in SMARCB1, a gene involved in chromatin remodeling. However, preliminary data from our lab using gene expression and DNA methylation arrays shows that there are three distinct molecular subgroups of AT/RTs, suggesting that other molecular alterations underlying the development of these aggressive pediatric brain tumors must be found outside the coding genome or at the epigenomic level. Identification of these (epi)genomic alterations, which we intend to address in this project, may lead to novel treatment strategies for these tumors and reveal options for meaningful patient stratification.",
+            "abstract": "Whole exome sequencing of atypical teratoid /rhabdoid tumors (AT/RTs) revealed recurrent mutations only in SMARCB1, a gene involved in chromatin remodeling. However, preliminary data from our lab using gene expression and DNA methylation arrays shows that there are three distinct molecular subgroups of AT/RTs, suggesting that other molecular alterations underlying the development of these aggressive pediatric brain tumors must be found outside the coding genome or at the epigenomic level. Identification of these (epi)genomic alterations, which we intend to address in this project, may lead to novel treatment strategies for these tumors and reveal options for meaningful patient stratification.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001001444",
+                "EGAD00001002135",
+                "EGAD00001002136",
+                "EGAD00001002137",
+                "EGAD00001002138"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-IBIOS-23-06-2015-07:58:29:604-312"
+            ],
+            "creation_date": "2015-06-23T05:40.000Z"
+        },
+        {
+            "id": "EGAS00001001394",
+            "title": "Genome-wide identification of distinct miRNA-mRNA target regulation pairs in Non-Hodgkin lymphomas: a report from the ICGC MMML-Seq consortium",
+            "description": "We obtained miRNA profiles by miRnome sequencing from ICGC MMML-Seq patients diagnosed with Burkitt lymphoma, diffuse large B-cell lymphoma and follicular lymphoma and provide evidence of subtype-specific miRNA expression differences. We describe differentially expressed, mutated, edited and not previously annotated miRNAs.\nAddditionally, by performing argonaute-2 photoactivatable ribonucleoside-enhanced cross-linking and immunoprecipitation (PAR-CLIP) experiments, we obtained a set of biochemically-validated miRNA binding sites and  identified miRNA-mRNA interaction pairs with a negative correlation in patient RNASeq data.",
+            "abstract": "We obtained miRNA profiles by miRnome sequencing from ICGC MMML-Seq patients diagnosed with Burkitt lymphoma, diffuse large B-cell lymphoma and follicular lymphoma and provide evidence of subtype-specific miRNA expression differences. We describe differentially expressed, mutated, edited and not previously annotated miRNAs.\nAddditionally, by performing argonaute-2 photoactivatable ribonucleoside-enhanced cross-linking and immunoprecipitation (PAR-CLIP) experiments, we obtained a set of biochemically-validated miRNA binding sites and  identified miRNA-mRNA interaction pairs with a negative correlation in patient RNASeq data.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001001468",
+                "EGAD00001001612"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-IBIOS-13-08-2015-07:31:20:378-254"
+            ],
+            "creation_date": "2015-08-13T05:29.000Z"
+        },
+        {
+            "id": "EGAS00001001746",
+            "title": "Drug-perturbation-based stratification of blood cancer",
+            "description": "As new generations of targeted therapies emerge and tumor genome sequencing discovers increasingly comprehensive mutation repertoires, the functional relationships of mutations to tumor phenotypes remain largely unknown. Here, we measured ex vivo sensitivity of 246 blood cancers to 63 drugs alongside genome, transcriptome, and DNA methylome analysis to understand determinants of drug response. We assembled a primary blood cancer cell encyclopedia data set that revealed disease-specific sensitivities for each cancer. Within chronic lymphocytic leukemia (CLL), responses to 62% of drugs were associated with 2 or more mutations, and linked the B cell receptor (BCR) pathway to trisomy 12, an important driver of CLL. Based on drug responses, the disease could be organized into phenotypic subgroups characterized by exploitable dependencies on BCR, mTOR, or MEK signaling and associated with mutations, gene expression, and DNA methylation. Fourteen percent of CLLs were driven by mTOR signaling in a non\u2013BCR-dependent manner. Multivariate modeling revealed immunoglobulin heavy chain variable gene (IGHV) mutation status and trisomy 12 as the most important modulators of response to kinase inhibitors in CLL. Ex vivo drug responses were associated with outcome. This study overcomes the perception that most mutations do not influence drug response of cancer, and points to an updated approach to understanding tumor biology, with implications for biomarker discovery and cancer care.",
+            "abstract": "As new generations of targeted therapies emerge and tumor genome sequencing discovers increasingly comprehensive mutation repertoires, the functional relationships of mutations to tumor phenotypes remain largely unknown. Here, we measured ex vivo sensitivity of 246 blood cancers to 63 drugs alongside genome, transcriptome, and DNA methylome analysis to understand determinants of drug response. We assembled a primary blood cancer cell encyclopedia data set that revealed disease-specific sensitivities for each cancer. Within chronic lymphocytic leukemia (CLL), responses to 62% of drugs were associated with 2 or more mutations, and linked the B cell receptor (BCR) pathway to trisomy 12, an important driver of CLL. Based on drug responses, the disease could be organized into phenotypic subgroups characterized by exploitable dependencies on BCR, mTOR, or MEK signaling and associated with mutations, gene expression, and DNA methylation. Fourteen percent of CLLs were driven by mTOR signaling in a non\u2013BCR-dependent manner. Multivariate modeling revealed immunoglobulin heavy chain variable gene (IGHV) mutation status and trisomy 12 as the most important modulators of response to kinase inhibitors in CLL. Ex vivo drug responses were associated with outcome. This study overcomes the perception that most mutations do not influence drug response of cancer, and points to an updated approach to understanding tumor biology, with implications for biomarker discovery and cancer care.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001002055",
+                "EGAD00001002056",
+                "EGAD00010000947",
+                "EGAD00010000948",
+                "EGAD00010000949"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-HIPO-03-03-2016-10:10:56:379-20"
+            ],
+            "creation_date": "2016-03-03T09:02.000Z"
+        },
+        {
+            "id": "EGAS00001001784",
+            "title": "Analysis of tumor periphery and center-specific mutations in renal cell carcinoma",
+            "description": "Renal cell carcinoma (RCC) is a genomically heterogeneous tumor. In the present project, the question whether intratumoral heterogeneity follows a zonal pattern indicating spatial niches was addressed. Whole exome sequencing of 16 paired samples from tumor periphery and center revealed a number of region-specific functional SNVs and Indels. Therefore, RCCs are not composed of evenly admixed tumor cells but show topological differences in their clonal composition.",
+            "abstract": "Renal cell carcinoma (RCC) is a genomically heterogeneous tumor. In the present project, the question whether intratumoral heterogeneity follows a zonal pattern indicating spatial niches was addressed. Whole exome sequencing of 16 paired samples from tumor periphery and center revealed a number of region-specific functional SNVs and Indels. Therefore, RCCs are not composed of evenly admixed tumor cells but show topological differences in their clonal composition.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001002067"
+            ],
+            "xref": [
+                "ena-STUDY-MUO-19-04-2016-11:18:19:401-62"
+            ],
+            "creation_date": "2016-04-19T13:21.000Z"
+        },
+        {
+            "id": "EGAS00001001844",
+            "title": "Targeting FGFR1 for treatment of soft-tissue sarcoma (H021)",
+            "description": "Purpose: Altered FGFR1 signaling has emerged as therapeutic target in various epithelial malignancies. In contrast, the role of FGFR1 in soft-tissue sarcoma (STS) has not been established. Prompted by the detection and subsequent therapeutic inhibition of amplified FGFR1 in a patient with metastatic leiomyosarcoma, we investigated the oncogenic properties and potential as drug target of FGFR1 in STS.Experimental Design: The frequency of FGFR1 amplification and overexpression, as assessed by fluorescence in situ hybridization, microarray-based comparative genomic hybridization and mRNA expression profiling, SNP array profiling, and RNA sequencing, was determined in three independent patient cohorts. The sensitivity of STS cell lines with or without FGFR1 alterations to genetic and pharmacologic FGFR1 inhibition and the signaling pathways engaged by FGFR1 were investigated using short-term viability assays, long-term colony formation assays, and biochemical analysis.Results: Increased FGFR1 copy number was detected in 74 of 190 (38.9%; Cohort 1), 13 of 79 (16.5%; Cohort 2), and 80 of 254 (31.5%; Cohort 3) patients. FGFR1 overexpression occurred in 16 of 79 (20.2%, Cohort 2) and 39 of 254 (15.4%; Cohort 3) patients. Targeting of FGFR1 by short hairpin RNA-mediated knockdown and different small-molecule inhibitors (PD173074, AZD4547, BGJ398) revealed that the requirement for FGFR1 signaling in STS cells is primarily dictated by FGFR1 expression levels, and identified the MAPK-ERK1/2 axis as critical FGFR1 effector pathway.Conclusion: These data identify FGFR1 as driver gene in multiple STS subtypes and support FGFR1 inhibition, guided by patient selection according to FGFR1 expression and monitoring of MAPK-ERK1/2 signaling, as therapeutic option in this challenging group of diseases.H021",
+            "abstract": "Purpose: Altered FGFR1 signaling has emerged as therapeutic target in various epithelial malignancies. In contrast, the role of FGFR1 in soft-tissue sarcoma (STS) has not been established. Prompted by the detection and subsequent therapeutic inhibition of amplified FGFR1 in a patient with metastatic leiomyosarcoma, we investigated the oncogenic properties and potential as drug target of FGFR1 in STS.Experimental Design: The frequency of FGFR1 amplification and overexpression, as assessed by fluorescence in situ hybridization, microarray-based comparative genomic hybridization and mRNA expression profiling, SNP array profiling, and RNA sequencing, was determined in three independent patient cohorts. The sensitivity of STS cell lines with or without FGFR1 alterations to genetic and pharmacologic FGFR1 inhibition and the signaling pathways engaged by FGFR1 were investigated using short-term viability assays, long-term colony formation assays, and biochemical analysis.Results: Increased FGFR1 copy number was detected in 74 of 190 (38.9%; Cohort 1), 13 of 79 (16.5%; Cohort 2), and 80 of 254 (31.5%; Cohort 3) patients. FGFR1 overexpression occurred in 16 of 79 (20.2%, Cohort 2) and 39 of 254 (15.4%; Cohort 3) patients. Targeting of FGFR1 by short hairpin RNA-mediated knockdown and different small-molecule inhibitors (PD173074, AZD4547, BGJ398) revealed that the requirement for FGFR1 signaling in STS cells is primarily dictated by FGFR1 expression levels, and identified the MAPK-ERK1/2 axis as critical FGFR1 effector pathway.Conclusion: These data identify FGFR1 as driver gene in multiple STS subtypes and support FGFR1 inhibition, guided by patient selection according to FGFR1 expression and monitoring of MAPK-ERK1/2 signaling, as therapeutic option in this challenging group of diseases.H021",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001002159"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-HIPO-23-05-2016-08:10:16:493-7"
+            ],
+            "creation_date": "2016-05-23T13:19.000Z"
+        },
+        {
+            "id": "EGAS00001001845",
+            "title": "Mutant KIT as imatinib-sensitive target in metastatic sinonasal carcinoma (H021)",
+            "description": "Sinonasal carcinomas (SNCs) comprise various rare tumor types that are characterized by marked histologic diversity and largely unknown molecular profiles, yet share an overall poor prognosis owing to an aggressive clinical course and frequent late-stage diagnosis. The lack of effective systemic therapies for locally advanced or metastatic SNC poses a major challenge to therapeutic decision making for individual patients. Here, we used whole-exome and transcriptome sequencing to identify a KIT exon 11 mutation (c.1733_1735del, p.578_579del) as actionable target in a patient with metastatic SNC whose tumor, despite all diagnostic efforts, could not be assigned to any known SNC category and was refractory to multimodal therapy. Molecularly guided treatment with imatinib resulted in a dramatic and durable response with remission of nearly all tumor manifestations, indicating a dominant driver function of mutant KIT in this tumor. This observation highlights the potential of unbiased genomic profiling for uncovering the vulnerabilities of individual malignancies, particularly in rare and unclassifiable tumors, and underscores that KIT exon 11 mutations represent tractable therapeutic targets across different histologies.H021",
+            "abstract": "Sinonasal carcinomas (SNCs) comprise various rare tumor types that are characterized by marked histologic diversity and largely unknown molecular profiles, yet share an overall poor prognosis owing to an aggressive clinical course and frequent late-stage diagnosis. The lack of effective systemic therapies for locally advanced or metastatic SNC poses a major challenge to therapeutic decision making for individual patients. Here, we used whole-exome and transcriptome sequencing to identify a KIT exon 11 mutation (c.1733_1735del, p.578_579del) as actionable target in a patient with metastatic SNC whose tumor, despite all diagnostic efforts, could not be assigned to any known SNC category and was refractory to multimodal therapy. Molecularly guided treatment with imatinib resulted in a dramatic and durable response with remission of nearly all tumor manifestations, indicating a dominant driver function of mutant KIT in this tumor. This observation highlights the potential of unbiased genomic profiling for uncovering the vulnerabilities of individual malignancies, particularly in rare and unclassifiable tumors, and underscores that KIT exon 11 mutations represent tractable therapeutic targets across different histologies.H021",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001002160",
+                "EGAD00001002161"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-HIPO-23-05-2016-09:30:27:839-9"
+            ],
+            "creation_date": "2016-05-23T13:19.000Z"
+        },
+        {
+            "id": "EGAS00001001846",
+            "title": "Integration of genomics and histology reveals diagnosis and effective therapy of refractory cancer of unknown primary with PDL1 amplification (H021)",
+            "description": "Identification of the tissue of origin in cancer of unknown primary (CUP) poses a diagnostic challenge and is critical for directing site-specific therapy. Currently, clinical decision making in patients with CUP primarily relies on histopathology and clinical features. Comprehensive molecular profiling has the potential to contribute to diagnostic categorization and, most importantly, guide CUP therapy through identification of actionable lesions. We here report the case of an advanced-stage malignancy initially mimicking poorly differentiated soft-tissue sarcoma that did not respond to multi-agent chemotherapy. Molecular profiling within a clinical whole-exome and transcriptome sequencing program revealed a heterozygous, highly amplified KRAS G12S mutation, compound-heterozygous TP53 mutation/deletion, high mutational load, and focal amplification of chromosomes 9p (including PDL1 [CD274] and JAK2) and 10p (including GATA3). Integrated analysis of molecular data and conventional histopathology suggested a diagnosis of triple-negative breast cancer (TNBC) and provided a rationale for immune checkpoint inhibitor therapy with pembrolizumab, which resulted in rapid clinical improvement and a lasting partial remission. Analysis of 157 TNBC samples from The Cancer Genome Atlas revealed focal, high-level PDL1 amplification coinciding with excessive PDL1 mRNA expression in 24% of cases. Collectively, these results illustrate the diagnostic utility of multidimensional tumor profiling in cases with non-descript histology and immune phenotype, demonstrate the predictive power of genomic PDL1 amplification for immune checkpoint inhibition, and suggest a targeted therapeutic strategy in chromosome 9p24.1/PDL1-amplified cancers.H021",
+            "abstract": "Identification of the tissue of origin in cancer of unknown primary (CUP) poses a diagnostic challenge and is critical for directing site-specific therapy. Currently, clinical decision making in patients with CUP primarily relies on histopathology and clinical features. Comprehensive molecular profiling has the potential to contribute to diagnostic categorization and, most importantly, guide CUP therapy through identification of actionable lesions. We here report the case of an advanced-stage malignancy initially mimicking poorly differentiated soft-tissue sarcoma that did not respond to multi-agent chemotherapy. Molecular profiling within a clinical whole-exome and transcriptome sequencing program revealed a heterozygous, highly amplified KRAS G12S mutation, compound-heterozygous TP53 mutation/deletion, high mutational load, and focal amplification of chromosomes 9p (including PDL1 [CD274] and JAK2) and 10p (including GATA3). Integrated analysis of molecular data and conventional histopathology suggested a diagnosis of triple-negative breast cancer (TNBC) and provided a rationale for immune checkpoint inhibitor therapy with pembrolizumab, which resulted in rapid clinical improvement and a lasting partial remission. Analysis of 157 TNBC samples from The Cancer Genome Atlas revealed focal, high-level PDL1 amplification coinciding with excessive PDL1 mRNA expression in 24% of cases. Collectively, these results illustrate the diagnostic utility of multidimensional tumor profiling in cases with non-descript histology and immune phenotype, demonstrate the predictive power of genomic PDL1 amplification for immune checkpoint inhibition, and suggest a targeted therapeutic strategy in chromosome 9p24.1/PDL1-amplified cancers.H021",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001002162",
+                "EGAD00001002163"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-HIPO-23-05-2016-09:36:42:065-13"
+            ],
+            "creation_date": "2016-05-23T13:19.000Z"
+        },
+        {
+            "id": "EGAS00001001848",
+            "title": "Evolution of a FLT3-TKD mutated subclone at meningeal relapse in acute promyelocytic leukemia (H021)",
+            "description": "Here we report the case of an acute promyelocytic leukemia (APL) patient who, though negative for FLT3 mutations at diagnosis, developed isolated FLT3-TKD positive meningeal relapse, which, in retrospect, could be traced back to a minute bone marrow subclone present at first diagnosis. Initially, the 48-year old female diagnosed with high-risk APL had achieved complete molecular remission after standard treatment with all-trans retinoic acid (ATRA) and chemotherapy according to the AIDA protocol. 13 months after start of ATRA maintenance the patient suffered clinically overt meningeal relapse along with minute molecular traces of PML/RARA in the bone marrow. Following treatment with arsenic trioxide (ATO) and ATRA in combination with intrathecal cytarabine and methotrexate, the patient achieved a complete molecular remission in both cerebrospinal fluid (CSF) and bone marrow, which currently lasts for two years after completion of therapy. Whole exome sequencing and subsequent ultradeep targeted re-sequencing revealed a heterozygous FLT3-TKD mutation in CSF leukemic cells (p.D835Y, c.2503G&gt;T, 1000/1961 reads (51%)), which was undetectable in the concurrent bone marrow sample. Interestingly, the FLT3-TKD mutated meningeal clone originated from a small bone marrow subclone present in a variant allele frequency of 0.4% (6/1553 reads) at initial diagnosis. This case highlights the concept of clonal evolution with a subclone harboring an additional mutation being selected as the \u201cfittest\u201d and leading to meningeal relapse. It also further supports earlier suggestions that FLT3 mutations may play a role for migration and clonal expansion in the CSF sanctuary site.H021",
+            "abstract": "Here we report the case of an acute promyelocytic leukemia (APL) patient who, though negative for FLT3 mutations at diagnosis, developed isolated FLT3-TKD positive meningeal relapse, which, in retrospect, could be traced back to a minute bone marrow subclone present at first diagnosis. Initially, the 48-year old female diagnosed with high-risk APL had achieved complete molecular remission after standard treatment with all-trans retinoic acid (ATRA) and chemotherapy according to the AIDA protocol. 13 months after start of ATRA maintenance the patient suffered clinically overt meningeal relapse along with minute molecular traces of PML/RARA in the bone marrow. Following treatment with arsenic trioxide (ATO) and ATRA in combination with intrathecal cytarabine and methotrexate, the patient achieved a complete molecular remission in both cerebrospinal fluid (CSF) and bone marrow, which currently lasts for two years after completion of therapy. Whole exome sequencing and subsequent ultradeep targeted re-sequencing revealed a heterozygous FLT3-TKD mutation in CSF leukemic cells (p.D835Y, c.2503G&gt;T, 1000/1961 reads (51%)), which was undetectable in the concurrent bone marrow sample. Interestingly, the FLT3-TKD mutated meningeal clone originated from a small bone marrow subclone present in a variant allele frequency of 0.4% (6/1553 reads) at initial diagnosis. This case highlights the concept of clonal evolution with a subclone harboring an additional mutation being selected as the \u201cfittest\u201d and leading to meningeal relapse. It also further supports earlier suggestions that FLT3 mutations may play a role for migration and clonal expansion in the CSF sanctuary site.H021",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001002164"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-HIPO-23-05-2016-20:08:44:897-46"
+            ],
+            "creation_date": "2016-05-23T18:49.000Z"
+        },
+        {
+            "id": "EGAS00001001857",
+            "title": "Genetic subclone heterogeneity of tumor-initiating cells in human colorectal cancer",
+            "description": "A subset of tumor-initiating cells (TIC) drives colorectal cancer (CRC) progression in serial mouse xenografts. The TIC compartment itself is heterogeneous and comprises hierarchically organized long-term TIC, tumor transient amplifying cells, and delayed contributing TIC. To address the genomic heterogeneity of the CRC TIC compartment, genome-wide high-coverage whole genome sequencing was performed on patient tumors (n=3), corresponding serially passaged TIC-enriched spheres, and serial xenografts.HIPO P002",
+            "abstract": "A subset of tumor-initiating cells (TIC) drives colorectal cancer (CRC) progression in serial mouse xenografts. The TIC compartment itself is heterogeneous and comprises hierarchically organized long-term TIC, tumor transient amplifying cells, and delayed contributing TIC. To address the genomic heterogeneity of the CRC TIC compartment, genome-wide high-coverage whole genome sequencing was performed on patient tumors (n=3), corresponding serially passaged TIC-enriched spheres, and serial xenografts.HIPO P002",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001002528"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-HIPO-29-05-2016-17:53:27:428-42"
+            ],
+            "creation_date": "2016-05-29T21:55.000Z"
+        },
+        {
+            "id": "EGAS00001001861",
+            "title": "Molecular evolution of metastatic clear cell renal cell carcinoma progressing under tyrosine kinase inhibitor therapy (HIPO-045)",
+            "description": "Background:Acquired resistance to targeted drugs is largely due to intra-tumor molecular heterogeneity and clonal selection. Objective:The objective of this study was to determine molecular alterations and mediating resistant mechanisms and to suggest additional treatment options.Design, Setting, and Participants:Four patients were enrolled into the MORE (Molecular Renal Cancer Evolution) trial. We investigated the mutational spectra of metastatic clear cell renal cell carcinoma (ccRCC) at baseline and compared them to those upon clonal evolution at progression on systemic therapy with tyrosine kinase inhibitors.Outcome Measurements:DNA was isolated from tumor tissues after surgery, metastasis biopsies after progression on sunitinib or axitinib, and subjected to whole-exome sequencing (WES). In addition, the exomes of circulating tumor DNA (ctDNA) from two patients were sequenced at baseline and at progression.Results and Limitations:Our data provide evidence for clonal evolution and various acquired resistance mechanisms of ccRCC with subclonal mutations in FLT4, MTOR, ITGA3/5, SETD2, and VHL on metastatic progression. The limited number of shared mutations in tissue and plasma biopsies indicates that both sources provide complementary information, possibly due to mutations present in metastatic lesions which were not amenable to tissue sampling but are represented in the ctDNA. Conclusion:Acquired resistance to targeted therapies in metastatic ccRCC is due to intra-tumor heterogeneity and clonal evolution. Larger patient cohorts have to be studied to estimate the benefit of WES from biopsies and ctDNA for therapy decision in metastatic ccRCC.Patient Summary:We analyzed the molecular profiles of ccRCC patients in primary tissues and metastatic tissues upon progression on tyrosine kinase inhibitor therapy. Clinically relevant mutations upon progression were detected in the metastatic sites of all of four patients, suggesting that it might be possible to derive therapies based on sequencing the metastases.?HIPO-045",
+            "abstract": "Background:Acquired resistance to targeted drugs is largely due to intra-tumor molecular heterogeneity and clonal selection. Objective:The objective of this study was to determine molecular alterations and mediating resistant mechanisms and to suggest additional treatment options.Design, Setting, and Participants:Four patients were enrolled into the MORE (Molecular Renal Cancer Evolution) trial. We investigated the mutational spectra of metastatic clear cell renal cell carcinoma (ccRCC) at baseline and compared them to those upon clonal evolution at progression on systemic therapy with tyrosine kinase inhibitors.Outcome Measurements:DNA was isolated from tumor tissues after surgery, metastasis biopsies after progression on sunitinib or axitinib, and subjected to whole-exome sequencing (WES). In addition, the exomes of circulating tumor DNA (ctDNA) from two patients were sequenced at baseline and at progression.Results and Limitations:Our data provide evidence for clonal evolution and various acquired resistance mechanisms of ccRCC with subclonal mutations in FLT4, MTOR, ITGA3/5, SETD2, and VHL on metastatic progression. The limited number of shared mutations in tissue and plasma biopsies indicates that both sources provide complementary information, possibly due to mutations present in metastatic lesions which were not amenable to tissue sampling but are represented in the ctDNA. Conclusion:Acquired resistance to targeted therapies in metastatic ccRCC is due to intra-tumor heterogeneity and clonal evolution. Larger patient cohorts have to be studied to estimate the benefit of WES from biopsies and ctDNA for therapy decision in metastatic ccRCC.Patient Summary:We analyzed the molecular profiles of ccRCC patients in primary tissues and metastatic tissues upon progression on tyrosine kinase inhibitor therapy. Clinically relevant mutations upon progression were detected in the metastatic sites of all of four patients, suggesting that it might be possible to derive therapies based on sequencing the metastases.?HIPO-045",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001002166"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-HIPO-01-06-2016-10:11:00:057-50"
+            ],
+            "creation_date": "2016-06-01T08:03.000Z"
+        },
+        {
+            "id": "EGAS00001001950",
+            "title": "Mutational landscape of renal cell carcinoma with venous tumor thrombus",
+            "description": "Renal cell carcinoma with venous tumor thrombus opens the unique opportunity to investigate the clonal evolution of a tumor in two fundamentally different compartments i.e., within the confinement of an organ and inside a large blood vessel. We performed multiregion whole exome sequencing of a total of 37 samples from five consecutive patients (normal tissue, n=5; primary tumors, n=16; tumor thrombi, n=16) to &gt;35-fold target coverage. Four patients had a clear cell RCC, one patient had a poorly differentiated type II papillary RCC (RCC-VTT-04). The latter patient had a friable thrombus, the others were of solid consistency.",
+            "abstract": "Renal cell carcinoma with venous tumor thrombus opens the unique opportunity to investigate the clonal evolution of a tumor in two fundamentally different compartments i.e., within the confinement of an organ and inside a large blood vessel. We performed multiregion whole exome sequencing of a total of 37 samples from five consecutive patients (normal tissue, n=5; primary tumors, n=16; tumor thrombi, n=16) to &gt;35-fold target coverage. Four patients had a clear cell RCC, one patient had a poorly differentiated type II papillary RCC (RCC-VTT-04). The latter patient had a friable thrombus, the others were of solid consistency.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001004887"
+            ],
+            "xref": [
+                "ena-STUDY-MUO-01-09-2016-16:00:34:342-90"
+            ],
+            "creation_date": "2016-09-01T14:47.000Z"
+        },
+        {
+            "id": "EGAS00001002270",
+            "title": "Genomic profiling of Acute Lymphoblastic Leukemia in Ataxia Telangiectasia patients reveals tight link between ATM mutations and chromothripsis",
+            "description": "Recent developments in sequencing technologies led to the discovery of a novel form of genomic instability, termed chromothripsis. This catastrophic genomic event, involved in tumorigenesis, is characterized by tens to hundreds of simultaneously acquired locally clustered rearrangements on one chromosome. We hypothesized that leukemias developing in individuals with Ataxia Telangiectasia, who are born with two mutated copies of the ATM gene, an essential guardian of genome stability, would show a higher prevalence of chromothripsis due to the associated defect in DNA double-strand break repair. Using whole-genome sequencing, fluorescence in situ hybridization and RNA sequencing, we characterized the genomic landscape of Acute Lymphoblastic Leukemia (ALL) arising in patients with Ataxia Telangiectasia. We detected a high frequency of chromothriptic events in these tumors, specifically on acrocentric chromosomes, as compared to tumors from individuals with other types of DNA repair syndromes (27 cases total, 10 with Ataxia Telangiectasia). Our data suggest that the genomic landscape of Ataxia Telangiectasia ALL is clearly distinct from that of sporadic ALL. Mechanistically, short telomeres and compromised DNA damage response in cells of Ataxia Telangiectasia patients may be linked with frequent chromothripsis. Furthermore, we show that ATM loss is associated with increased chromothripsis prevalence in additional tumor entities.",
+            "abstract": "Recent developments in sequencing technologies led to the discovery of a novel form of genomic instability, termed chromothripsis. This catastrophic genomic event, involved in tumorigenesis, is characterized by tens to hundreds of simultaneously acquired locally clustered rearrangements on one chromosome. We hypothesized that leukemias developing in individuals with Ataxia Telangiectasia, who are born with two mutated copies of the ATM gene, an essential guardian of genome stability, would show a higher prevalence of chromothripsis due to the associated defect in DNA double-strand break repair. Using whole-genome sequencing, fluorescence in situ hybridization and RNA sequencing, we characterized the genomic landscape of Acute Lymphoblastic Leukemia (ALL) arising in patients with Ataxia Telangiectasia. We detected a high frequency of chromothriptic events in these tumors, specifically on acrocentric chromosomes, as compared to tumors from individuals with other types of DNA repair syndromes (27 cases total, 10 with Ataxia Telangiectasia). Our data suggest that the genomic landscape of Ataxia Telangiectasia ALL is clearly distinct from that of sporadic ALL. Mechanistically, short telomeres and compromised DNA damage response in cells of Ataxia Telangiectasia patients may be linked with frequent chromothripsis. Furthermore, we show that ATM loss is associated with increased chromothripsis prevalence in additional tumor entities.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001003429",
+                "EGAD00001003430",
+                "EGAD00001003436",
+                "EGAD00001003437",
+                "EGAD00001003438",
+                "EGAD00001003439",
+                "EGAD00001003440"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-07-02-2017-08:33:32:775-288"
+            ],
+            "creation_date": "2017-02-07T07:39.000Z"
+        },
+        {
+            "id": "EGAS00001002377",
+            "title": "Tumor-derived exosomes modulate PD-L1 expression in monocytes",
+            "description": "In chronic lymphocytic leukemia (CLL), monocytes and macrophages are skewed toward protumorigenic phenotypes, including the release of tumor-supportive cytokines and the expression of immunosuppressive molecules such as programmed cell death 1 ligand 1 (PD-L1). To understand the mechanism driving protumorigenic skewing in CLL, we evaluated the role of tumor cell\u2013derived exosomes in the cross-talk with monocytes. We carried out RNA sequencing and proteome analyses of CLL-derived exosomes and identified noncoding Y RNA hY4 as a highly abundant RNA species that is enriched in exosomes from plasma of CLL patients compared with healthy donor samples. Transfer of CLL-derived exosomes or hY4 alone to monocytes resulted in key CLL-associated phenotypes, including the release of cytokines, such as C-C motif chemokine ligand 2 (CCL2), CCL4, and interleukin-6, and the expression of PD-L1. These responses were abolished in Toll-like receptor 7 (TLR7)\u2013deficient monocytes, suggesting exosomal hY4 as a driver of TLR7 signaling. Pharmacologic inhibition of endosomal TLR signaling resulted in a substantially reduced activation of monocytes in vitro and attenuated CLL development in vivo. Our results indicate that exosome-mediated transfer of noncoding RNAs to monocytes contributes to cancer-related inflammation and concurrent immune escape via PD-L1 expression.",
+            "abstract": "In chronic lymphocytic leukemia (CLL), monocytes and macrophages are skewed toward protumorigenic phenotypes, including the release of tumor-supportive cytokines and the expression of immunosuppressive molecules such as programmed cell death 1 ligand 1 (PD-L1). To understand the mechanism driving protumorigenic skewing in CLL, we evaluated the role of tumor cell\u2013derived exosomes in the cross-talk with monocytes. We carried out RNA sequencing and proteome analyses of CLL-derived exosomes and identified noncoding Y RNA hY4 as a highly abundant RNA species that is enriched in exosomes from plasma of CLL patients compared with healthy donor samples. Transfer of CLL-derived exosomes or hY4 alone to monocytes resulted in key CLL-associated phenotypes, including the release of cytokines, such as C-C motif chemokine ligand 2 (CCL2), CCL4, and interleukin-6, and the expression of PD-L1. These responses were abolished in Toll-like receptor 7 (TLR7)\u2013deficient monocytes, suggesting exosomal hY4 as a driver of TLR7 signaling. Pharmacologic inhibition of endosomal TLR signaling resulted in a substantially reduced activation of monocytes in vitro and attenuated CLL development in vivo. Our results indicate that exosome-mediated transfer of noncoding RNAs to monocytes contributes to cancer-related inflammation and concurrent immune escape via PD-L1 expression.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001003230"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-15-03-2017-12:45:09:431-148"
+            ],
+            "creation_date": "2017-03-15T11:18.000Z"
+        },
+        {
+            "id": "EGAS00001002437",
+            "title": "Integrative genomic and transcriptomic analysis of adult leiomyosarcoma (HIPO-028, HIPO-018, HIPO-021)",
+            "description": "Leiomyosarcoma (LMS) is an aggressive mesenchmyal malignancy with few therapeutic options. The mechanisms underlying LMS development, including clinically actionable genetic vulnerabilities, are largely unknown. We performed genomic and transcriptomic profiling of a large cohort of LMS tumors and identified substantial mutational heterogeneity, near-universal inactivation of TP53 and RB1, widespread DNA copy number alterations, chromothripsis, and frequent whole-genome duplication. Furthermore, we discovered recurrent alterations in telomere maintenance genes such as ATRX, RBL2, and RPA1, resulting in alternative lengthening of telomeres in 78% of cases. Finally, most tumors displayed hallmarks of \u201cBRCAness\u201d, including alterations in various homologous recombination DNA repair genes, multiple structural rearrangements, and enrichment of specific mutational signatures, and cultured LMS cells were sensitive towards olaparib and cisplatin treatment. This first comprehensive study of genetic alterations in LMS has uncovered key biological features that may inform future experimental research and enable the design of novel therapeutic strategies for this disease.",
+            "abstract": "Leiomyosarcoma (LMS) is an aggressive mesenchmyal malignancy with few therapeutic options. The mechanisms underlying LMS development, including clinically actionable genetic vulnerabilities, are largely unknown. We performed genomic and transcriptomic profiling of a large cohort of LMS tumors and identified substantial mutational heterogeneity, near-universal inactivation of TP53 and RB1, widespread DNA copy number alterations, chromothripsis, and frequent whole-genome duplication. Furthermore, we discovered recurrent alterations in telomere maintenance genes such as ATRX, RBL2, and RPA1, resulting in alternative lengthening of telomeres in 78% of cases. Finally, most tumors displayed hallmarks of \u201cBRCAness\u201d, including alterations in various homologous recombination DNA repair genes, multiple structural rearrangements, and enrichment of specific mutational signatures, and cultured LMS cells were sensitive towards olaparib and cisplatin treatment. This first comprehensive study of genetic alterations in LMS has uncovered key biological features that may inform future experimental research and enable the design of novel therapeutic strategies for this disease.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001003827",
+                "EGAD00001003828",
+                "EGAD00001003829"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-HIPO-25-04-2017-17:13:07:370-329"
+            ],
+            "creation_date": "2017-04-25T15:12.000Z"
+        },
+        {
+            "id": "EGAS00001002441",
+            "title": "Successful immune checkpoint blockade in a patient with advanced stage microsatellite unstable biliary tract cancer (H021)",
+            "description": "Cancers acquire multiple somatic mutations that can lead to the generation of immunogenic mutation-induced neoantigens. These neoantigens can be recognized by the host\u2019s immune system. However, continuous stimulation of immune cells against tumor antigens can lead to immune cell exhaustion, which allows uncontrolled outgrowth of tumor cells. Recently, immune checkpoint inhibitors have emerged as a novel approach to overcome immune cell exhaustion and re-activate anti-tumor immune responses. In particular, antibodies blocking the exhaustion-mediating programmed death receptor (PD-1)/PD-L1 pathway have shown clinical efficacy. The effects were particularly pronounced in tumors with DNA mismatch repair deficiency and a high mutational load, which typically occur in the colon and  endometrium. Here, we report on a 24-year old woman diagnosed with extrahepatic cholangiocarcinoma who showed strong and durable response to the immune checkpoint inhibitor pembrolizumab, although treatment was initiated at an advanced stage of disease. The patient\u2019s tumor displayed DNA mismatch repair deficiency and microsatellite instability (MSI), but lacked other features commonly discussed as predictors of response towards checkpoint blockade, such as PD-L1 expression or dense infiltration with cytotoxic T cells. Notably, high levels of HLA class I and II antigen expression were detected in the tumor, suggesting a potential causal relation between functionality of the tumor\u2019s antigen presentation machinery and the success of immune checkpoint blockade. We suggest determining MSI status in combination with HLA class I and II antigen expression in tumors potentially eligible for immune checkpoint blockade even in the absence of conventional markers predictive for anti-PD-1/PD-L1 therapy and in entities not commonly linked to MSI phenotype. Further studies are required to determine the value of these markers for predicting the success of immune checkpoint blockade.  (H021)",
+            "abstract": "Cancers acquire multiple somatic mutations that can lead to the generation of immunogenic mutation-induced neoantigens. These neoantigens can be recognized by the host\u2019s immune system. However, continuous stimulation of immune cells against tumor antigens can lead to immune cell exhaustion, which allows uncontrolled outgrowth of tumor cells. Recently, immune checkpoint inhibitors have emerged as a novel approach to overcome immune cell exhaustion and re-activate anti-tumor immune responses. In particular, antibodies blocking the exhaustion-mediating programmed death receptor (PD-1)/PD-L1 pathway have shown clinical efficacy. The effects were particularly pronounced in tumors with DNA mismatch repair deficiency and a high mutational load, which typically occur in the colon and  endometrium. Here, we report on a 24-year old woman diagnosed with extrahepatic cholangiocarcinoma who showed strong and durable response to the immune checkpoint inhibitor pembrolizumab, although treatment was initiated at an advanced stage of disease. The patient\u2019s tumor displayed DNA mismatch repair deficiency and microsatellite instability (MSI), but lacked other features commonly discussed as predictors of response towards checkpoint blockade, such as PD-L1 expression or dense infiltration with cytotoxic T cells. Notably, high levels of HLA class I and II antigen expression were detected in the tumor, suggesting a potential causal relation between functionality of the tumor\u2019s antigen presentation machinery and the success of immune checkpoint blockade. We suggest determining MSI status in combination with HLA class I and II antigen expression in tumors potentially eligible for immune checkpoint blockade even in the absence of conventional markers predictive for anti-PD-1/PD-L1 therapy and in entities not commonly linked to MSI phenotype. Further studies are required to determine the value of these markers for predicting the success of immune checkpoint blockade.  (H021)",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001003325"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-HIPO-26-04-2017-14:27:01:528-7"
+            ],
+            "creation_date": "2017-04-26T12:06.000Z"
+        },
+        {
+            "id": "EGAS00001002536",
+            "title": "A biobank of patient-derived pediatric brain tumor models",
+            "description": "Brain tumors are the leading cause of cancer-related death in children. Genomic studies have provided insights into molecular\nsubgroups and oncogenic drivers of pediatric brain tumors that may lead to novel therapeutic strategies. To evaluate new\ntreatments, better preclinical models adequately reflecting the biological heterogeneity are needed. Through the Children\u2019s Oncology Group ACNS02B3 study, we have generated and comprehensively characterized 30 patient-derived orthotopic\nxenograft models and 7 cell lines representing 14 molecular subgroups of pediatric brain tumors. Patient-derived orthotopic\nxenograft models were found to be representative of the human tumors they were derived from in terms of histology, immunohistochemistry, gene expression, DNA methylation, copy number, and mutational profiles. In vivo drug sensitivity of targeted therapeutics was associated with distinct molecular tumor subgroups and specific genetic alterations. These models and their molecular characterization provide an unprecedented resource for the cancer community to study key oncogenic drivers and to evaluate novel treatment strategies.",
+            "abstract": "Brain tumors are the leading cause of cancer-related death in children. Genomic studies have provided insights into molecular\nsubgroups and oncogenic drivers of pediatric brain tumors that may lead to novel therapeutic strategies. To evaluate new\ntreatments, better preclinical models adequately reflecting the biological heterogeneity are needed. Through the Children\u2019s Oncology Group ACNS02B3 study, we have generated and comprehensively characterized 30 patient-derived orthotopic\nxenograft models and 7 cell lines representing 14 molecular subgroups of pediatric brain tumors. Patient-derived orthotopic\nxenograft models were found to be representative of the human tumors they were derived from in terms of histology, immunohistochemistry, gene expression, DNA methylation, copy number, and mutational profiles. In vivo drug sensitivity of targeted therapeutics was associated with distinct molecular tumor subgroups and specific genetic alterations. These models and their molecular characterization provide an unprecedented resource for the cancer community to study key oncogenic drivers and to evaluate novel treatment strategies.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001003544",
+                "EGAD00001003545",
+                "EGAD00001003573"
+            ],
+            "xref": [
+                "ena-STUDY-dkfz_b062-27-06-2017-13:10:10:718-409"
+            ],
+            "creation_date": "2017-06-27T11:12.000Z"
+        },
+        {
+            "id": "EGAS00001002696",
+            "title": "Therapeutic Targeting of Ependymoma as Informed by Oncogenic Enhancer Profiling",
+            "description": "Genomic sequencing has driven precision-based oncology therapy; however, genetic drivers remain unknown or non-targetable for many malignancies, demanding alternative approaches to identify therapeutic leads. Ependymomas are chemotherapy-resistant brain tumours, which, despite genomic sequencing, lack effective molecular targets. Here, we mapped active chromatin landscapes in 42 primary ependymomas in two non-overlapping primary ependymoma cohorts. Enhancer regions revealed novel oncogenes, molecular targets, and pathways, which when subjected to small molecule inhibitor or shRNA treatment, increased survival and slowed proliferation in mouse and neurosphere patient-derived models of ependymomas. This study represents one of the largest enhancer mapping study of any cancer type to date, and provides a framework for target and drug discovery for other cancers recalcitrant to therapeutic development because of their lack of known genetic drivers.",
+            "abstract": "Genomic sequencing has driven precision-based oncology therapy; however, genetic drivers remain unknown or non-targetable for many malignancies, demanding alternative approaches to identify therapeutic leads. Ependymomas are chemotherapy-resistant brain tumours, which, despite genomic sequencing, lack effective molecular targets. Here, we mapped active chromatin landscapes in 42 primary ependymomas in two non-overlapping primary ependymoma cohorts. Enhancer regions revealed novel oncogenes, molecular targets, and pathways, which when subjected to small molecule inhibitor or shRNA treatment, increased survival and slowed proliferation in mouse and neurosphere patient-derived models of ependymomas. This study represents one of the largest enhancer mapping study of any cancer type to date, and provides a framework for target and drug discovery for other cancers recalcitrant to therapeutic development because of their lack of known genetic drivers.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001003940",
+                "EGAD00001003966",
+                "EGAD00001003973",
+                "EGAD00001003979"
+            ],
+            "xref": [
+                "ena-STUDY-dkfz_b062-10-10-2017-12:54:56:165-253"
+            ],
+            "creation_date": "2017-10-10T10:59.000Z"
+        },
+        {
+            "id": "EGAS00001002717",
+            "title": "Defining the metastasome in colorectal cancer: Implications for hypotheses on metastasis evolution and personalized therapy (HIPO-032)",
+            "description": "Personalized cancer therapy aims at individual genetic changes characterizing primary cancers. Still, however, metastasis is the major clinically unmet problem, also due to an incomplete understanding of its molecular evolution.This study is the first to define the metastasis-specific whole genome landscape of human colorectal primary vs. matched metastatic lesions.Protein coding, ncRNA genes and 3\u2019UTRs harbored about a third each of single nucleotide variations (SNVs)/indels, 19% of them being metastasis-specific. We found novel mutational hills among ncRNAs and 3\u2019UTRs, copy number changes able to explain changes in microRNA expression in metastases, and novel metastasis-specific mutations in the 3\u2019UTRs on important cancer signalling genes. Some metastatic lesions showed targetable mutations not detected in the primaries. Analysis of mutual exclusivity patterns supported a model that has progressive alterations in important colorectal cancer genes and revealed new partners. Metastatic lesions were enriched in SNVs, specific structural variations, and alterations in genes affecting cell adhesion and extracellular matrix interaction.Furthermore, a hepatic stellate activation cascade was enriched in metastases, suggesting genetic programs for site-specific colonization. Allele frequency distribution and mutational signature analysis suggests a common ancestor clone to both the primary tumor and the metastasis, with additional mutagenesis ongoing in both sites independently. Taken together, our results significantly add to hypothesis generation on metastasis evolution, and suggest novel metastasis-specific genomic changes which would be missed by current personalized therapy concepts.  (HIPO-032)",
+            "abstract": "Personalized cancer therapy aims at individual genetic changes characterizing primary cancers. Still, however, metastasis is the major clinically unmet problem, also due to an incomplete understanding of its molecular evolution.This study is the first to define the metastasis-specific whole genome landscape of human colorectal primary vs. matched metastatic lesions.Protein coding, ncRNA genes and 3\u2019UTRs harbored about a third each of single nucleotide variations (SNVs)/indels, 19% of them being metastasis-specific. We found novel mutational hills among ncRNAs and 3\u2019UTRs, copy number changes able to explain changes in microRNA expression in metastases, and novel metastasis-specific mutations in the 3\u2019UTRs on important cancer signalling genes. Some metastatic lesions showed targetable mutations not detected in the primaries. Analysis of mutual exclusivity patterns supported a model that has progressive alterations in important colorectal cancer genes and revealed new partners. Metastatic lesions were enriched in SNVs, specific structural variations, and alterations in genes affecting cell adhesion and extracellular matrix interaction.Furthermore, a hepatic stellate activation cascade was enriched in metastases, suggesting genetic programs for site-specific colonization. Allele frequency distribution and mutational signature analysis suggests a common ancestor clone to both the primary tumor and the metastasis, with additional mutagenesis ongoing in both sites independently. Taken together, our results significantly add to hypothesis generation on metastasis evolution, and suggest novel metastasis-specific genomic changes which would be missed by current personalized therapy concepts.  (HIPO-032)",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001003965"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-HIPO-03-11-2017-15:22:57:743-41"
+            ],
+            "creation_date": "2017-11-03T14:59.000Z"
+        },
+        {
+            "id": "EGAS00001002720",
+            "title": "Defective Homologous Recombination DNA Repair as Therapeutic Target in Advanced-Stage Chordoma (HIPO_021)",
+            "description": "HIPO project: HIPO_021\nImportance: Chordomas are rare tumors of the axial skeleton and skull base with few therapeutic options and no clinically validated molecular drug targets. The value of comprehensive genomic analyses for guiding medical therapy of patients with advanced-stage chordoma is unknown.Objective: To identify therapeutically tractable genetic lesions in a cohort of chordoma patients within a genomics-guided precision oncology program and to document the outcome of individualized, molecularly targeted chordoma therapy.Design, Setting, and Participants: We performed whole-exome sequencing of tumor and matched germline control samples from seven patients with locally advanced or metastatic chordoma who were enrolled in a cross-institutional molecular stratification registry trial for younger adults with advanced-stage cancer across all histologies and patients with rare tumors. All patients were heavily pretreated and had progressive disease prior to molecular analysis.Interventions: Individualized medical therapy was administered according to the patients\u2019 molecular profiles.Main Outcomes and Measures: Candidate therapeutic targets identified by whole-exome sequencing and response to genotype-directed therapy.Results: All patients harbored alterations of two or more genes known to be involved in DNA repair via homologous recombination (HR), including heterozygous deletions of ERCC6, FANC family members, RAD51L (n = 6), BRCA2 (n = 5), ATR, CHEK2, RAD18, RAD51B, and XRCC3 (n = 4); inactivating PTEN mutations coupled with loss of heterozygosity (n = 2); and pathogenic germline variants in BRCA2 (n = 1), NBN (n = 1), and CHEK2 (n = 1) that were accompanied by somatic deletion of the corresponding wild-type alleles. Consistently, a mutational signature associated with defective HR was enriched in all samples and co-occurred with extensive genomic instability, as evidenced by HR deficiency scores and high numbers of large-scale state transitions. These results prompted off-label treatment with the poly(ADP-ribose) polymerase (PARP) inhibitor olaparib in a patient whose tumor was refractory to irradiation and systemic treatment with imatinib, which led to a prolonged response and substantial clinical improvement.Conclusions and Relevance: Advanced-stage chordomas are frequently characterized by genomic imprints of defective HR DNA repair. HR deficiency represents a new therapeutic opportunity in this intractable disease through repositioning of PARP inhibitors that warrants further exploration in clinical trials.",
+            "abstract": "HIPO project: HIPO_021\nImportance: Chordomas are rare tumors of the axial skeleton and skull base with few therapeutic options and no clinically validated molecular drug targets. The value of comprehensive genomic analyses for guiding medical therapy of patients with advanced-stage chordoma is unknown.Objective: To identify therapeutically tractable genetic lesions in a cohort of chordoma patients within a genomics-guided precision oncology program and to document the outcome of individualized, molecularly targeted chordoma therapy.Design, Setting, and Participants: We performed whole-exome sequencing of tumor and matched germline control samples from seven patients with locally advanced or metastatic chordoma who were enrolled in a cross-institutional molecular stratification registry trial for younger adults with advanced-stage cancer across all histologies and patients with rare tumors. All patients were heavily pretreated and had progressive disease prior to molecular analysis.Interventions: Individualized medical therapy was administered according to the patients\u2019 molecular profiles.Main Outcomes and Measures: Candidate therapeutic targets identified by whole-exome sequencing and response to genotype-directed therapy.Results: All patients harbored alterations of two or more genes known to be involved in DNA repair via homologous recombination (HR), including heterozygous deletions of ERCC6, FANC family members, RAD51L (n = 6), BRCA2 (n = 5), ATR, CHEK2, RAD18, RAD51B, and XRCC3 (n = 4); inactivating PTEN mutations coupled with loss of heterozygosity (n = 2); and pathogenic germline variants in BRCA2 (n = 1), NBN (n = 1), and CHEK2 (n = 1) that were accompanied by somatic deletion of the corresponding wild-type alleles. Consistently, a mutational signature associated with defective HR was enriched in all samples and co-occurred with extensive genomic instability, as evidenced by HR deficiency scores and high numbers of large-scale state transitions. These results prompted off-label treatment with the poly(ADP-ribose) polymerase (PARP) inhibitor olaparib in a patient whose tumor was refractory to irradiation and systemic treatment with imatinib, which led to a prolonged response and substantial clinical improvement.Conclusions and Relevance: Advanced-stage chordomas are frequently characterized by genomic imprints of defective HR DNA repair. HR deficiency represents a new therapeutic opportunity in this intractable disease through repositioning of PARP inhibitors that warrants further exploration in clinical trials.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001004825"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-HIPO-06-11-2017-11:29:19:108-138"
+            ],
+            "creation_date": "2017-11-06T10:21.000Z"
+        },
+        {
+            "id": "EGAS00001002759",
+            "title": "NRG1 Fusions in KRAS Wild-type Pancreatic Cancer (H021)",
+            "description": "We used whole-genome and transcriptome sequencing to identify clinically actionable gene fusions in young adults with KRAS wild-type (KRASwt) pancreatic ductal adenocarcinoma (PDAC). These alterations included recurrent NRG1 rearrangements predicted to drive PDAC development through aberrant ERBB receptor-mediated signaling, and pharmacologic ERBB inhibition resulted in clinical improvement and remission of liver metastases in two patients with NRG1-rearranged tumors that had proved resistant to standard treatment. Our findings demonstrate that systematic screening of KRASwt tumors for oncogenic fusion genes will substantially improve the therapeutic prospects for a sizeable fraction of PDAC patients.",
+            "abstract": "We used whole-genome and transcriptome sequencing to identify clinically actionable gene fusions in young adults with KRAS wild-type (KRASwt) pancreatic ductal adenocarcinoma (PDAC). These alterations included recurrent NRG1 rearrangements predicted to drive PDAC development through aberrant ERBB receptor-mediated signaling, and pharmacologic ERBB inhibition resulted in clinical improvement and remission of liver metastases in two patients with NRG1-rearranged tumors that had proved resistant to standard treatment. Our findings demonstrate that systematic screening of KRASwt tumors for oncogenic fusion genes will substantially improve the therapeutic prospects for a sizeable fraction of PDAC patients.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001004068"
+            ],
+            "xref": [
+                "ena-STUDY-DKFZ-HIPO-15-12-2017-09:21:38:637-158"
+            ],
+            "creation_date": "2017-12-15T08:09.000Z"
+        },
+        {
+            "id": "EGAS00001003027",
+            "title": "Allele Balance Bias Identifies Systematic Genotyping Errors and False Disease Associations",
+            "description": "In recent years, Next Generation Sequencing (NGS) has become a cornerstone of clinical genetics and diagnostics. Many clinical applications require high precision, especially if rare events such as somatic mutations in cancer or genetic variants causing rare diseases need to be identified. Although random sequencing errors can be modeled statistically and deep sequencing minimizes their impact, systematic errors remain a problem even at high depth of coverage. Understanding their source is crucial to increase precision of clinical NGS applications. In this work, we studied the relation between recurrent biases in allele balance (AB), systematic errors and false positive variant calls across a large cohort of human samples analyzed by whole exome sequencing (WES). We have modeled the allele balance distribution for biallelic genotypes in 987 WES samples in order to identify positions recurrently deviating significantly from the expectation, a phenomenon we termed allele balance bias (ABB). Furthermore, we have developed a genotype callability score based on ABB for all positions of the human exome, which detects false positive variant calls that passed state-of-the-art filters. Finally, we demonstrate the use of ABB for detection of false associations proposed by rare variant association studies (RVAS).",
+            "abstract": "In recent years, Next Generation Sequencing (NGS) has become a cornerstone of clinical genetics and diagnostics. Many clinical applications require high precision, especially if rare events such as somatic mutations in cancer or genetic variants causing rare diseases need to be identified. Although random sequencing errors can be modeled statistically and deep sequencing minimizes their impact, systematic errors remain a problem even at high depth of coverage. Understanding their source is crucial to increase precision of clinical NGS applications. In this work, we studied the relation between recurrent biases in allele balance (AB), systematic errors and false positive variant calls across a large cohort of human samples analyzed by whole exome sequencing (WES). We have modeled the allele balance distribution for biallelic genotypes in 987 WES samples in order to identify positions recurrently deviating significantly from the expectation, a phenomenon we termed allele balance bias (ABB). Furthermore, we have developed a genotype callability score based on ABB for all positions of the human exome, which detects false positive variant calls that passed state-of-the-art filters. Finally, we demonstrate the use of ABB for detection of false associations proposed by rare variant association studies (RVAS).",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001004132"
+            ],
+            "xref": [
+                "5b4dd757-9a4a-46fc-9133-d1dcd645fb53"
+            ],
+            "creation_date": "2018-05-25T12:38.000Z"
+        },
+        {
+            "id": "EGAS00001003140",
+            "title": "Automated image-based profiling of complex drug induced phenotypes in patient-derived organoids",
+            "description": "We established a platform for high-throughput confocal fluorescence microscopy and automated image analysis to perform large-scale drug response profiling with patient derived organoids (PDOs). Using PDO lines newly established from colorectal cancer patients with a standardized workflow, we performed chemical perturbations with more than 500 experimental and clinically used compounds. Subsequently, we captured approx. six million images by confocal microscopy. To analyze drug-induced PDO re-organization on a single organoid level we developed SCOPE, a software framework for automated PDO high-throughput image analysis. We observed a rich variety of divergent and reoccurring compound induced phenotypes in organoids. Perturbation of cellular processes, including signaling by MEK, GSK3\u03b2, cyclin dependent kinases (CDKs) and others, led to recurring and distinct architectural changes. Highlighting the clinical relevance, PDO viability was heterogeneous after perturbation with anticancer drugs and matched clinical response of corresponding colorectal cancer patients. Our work opens new avenues for image-based profiling for accelerated drug discovery and clinical decision-making.",
+            "abstract": "We established a platform for high-throughput confocal fluorescence microscopy and automated image analysis to perform large-scale drug response profiling with patient derived organoids (PDOs). Using PDO lines newly established from colorectal cancer patients with a standardized workflow, we performed chemical perturbations with more than 500 experimental and clinically used compounds. Subsequently, we captured approx. six million images by confocal microscopy. To analyze drug-induced PDO re-organization on a single organoid level we developed SCOPE, a software framework for automated PDO high-throughput image analysis. We observed a rich variety of divergent and reoccurring compound induced phenotypes in organoids. Perturbation of cellular processes, including signaling by MEK, GSK3\u03b2, cyclin dependent kinases (CDKs) and others, led to recurring and distinct architectural changes. Highlighting the clinical relevance, PDO viability was heterogeneous after perturbation with anticancer drugs and matched clinical response of corresponding colorectal cancer patients. Our work opens new avenues for image-based profiling for accelerated drug discovery and clinical decision-making.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001004313"
+            ],
+            "xref": [
+                "81ebb9cf-da1d-4c84-8be8-f44000e9cb8e"
+            ],
+            "creation_date": "2018-07-31T13:32.000Z"
+        },
+        {
+            "id": "EGAS00001003184",
+            "title": "Analysis of IDHwt-glioblastoma samples from paired primary and recurrent tumor samples",
+            "description": "IDHwt-glioblastomas rapidly recur after initial treatment. To study genetic evolution in glioblastoma, we analyzed whole genomes of 21 pairs of primary and recurrent tumor samples using next generation sequencing. In addition we sequenced RNA from 16 tumor pairs and a panel of 50 glioma-associated genes in tumor pairs from 43 patients (including 14 of the 21 patients included in the WGS discovery set). Glioblastoma subtypes were determined using 450k/EPIC methylation arrays.\n\nThis study was supported within the e:med program of the German Ministry of Education and Research (BMBF) by the collaborative research project \u2018SYS-GLIO - Systems-based prediction of the biological and clinical behavior of gliomas\u2019 (https://www.sys-med.de/de/demonstratoren/sys-glio/)\nThis study is part of the Heidelberg Center for Personalized Oncology - HIPO-043",
+            "abstract": "IDHwt-glioblastomas rapidly recur after initial treatment. To study genetic evolution in glioblastoma, we analyzed whole genomes of 21 pairs of primary and recurrent tumor samples using next generation sequencing. In addition we sequenced RNA from 16 tumor pairs and a panel of 50 glioma-associated genes in tumor pairs from 43 patients (including 14 of the 21 patients included in the WGS discovery set). Glioblastoma subtypes were determined using 450k/EPIC methylation arrays.\n\nThis study was supported within the e:med program of the German Ministry of Education and Research (BMBF) by the collaborative research project \u2018SYS-GLIO - Systems-based prediction of the biological and clinical behavior of gliomas\u2019 (https://www.sys-med.de/de/demonstratoren/sys-glio/)\nThis study is part of the Heidelberg Center for Personalized Oncology - HIPO-043",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001004563",
+                "EGAD00001004564",
+                "EGAD00001004565",
+                "EGAD00010001642",
+                "EGAD00010001643"
+            ],
+            "xref": [
+                "a59fe2b9-cf0c-408d-a52e-d716bfb746e5"
+            ],
+            "creation_date": "2018-08-30T14:34.000Z"
+        },
+        {
+            "id": "EGAS00001003248",
+            "title": "Epigenetics/genetics of the patient-derived xenografts of pediatric T-cell leukemia",
+            "description": "We compared 12 pediatric T cell acute lymphoblastic leukemias collected at initial diagnosis and relapse with their corresponding PDX models. The analysis was performed on genomic level (whole genome sequencing (WGS), whole exome sequencing (WES), multiplex ligation probe amplification (MLPA), targeted sequencing) and the epigenetic level (DNA methylation, Assay for Transposase-Accessible Chromatin sequencing (ATAC-seq)). In sum, this study underlines the remarkable genomic stability, and for the first time documents the preservation of the epigenomic landscape in T-ALL-derived PDX models.",
+            "abstract": "We compared 12 pediatric T cell acute lymphoblastic leukemias collected at initial diagnosis and relapse with their corresponding PDX models. The analysis was performed on genomic level (whole genome sequencing (WGS), whole exome sequencing (WES), multiplex ligation probe amplification (MLPA), targeted sequencing) and the epigenetic level (DNA methylation, Assay for Transposase-Accessible Chromatin sequencing (ATAC-seq)). In sum, this study underlines the remarkable genomic stability, and for the first time documents the preservation of the epigenomic landscape in T-ALL-derived PDX models.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001004459"
+            ],
+            "xref": [
+                "29a5852a-8105-4ae1-88ed-0786fad0ccd9"
+            ],
+            "creation_date": "2018-10-04T09:17.000Z"
+        },
+        {
+            "id": "EGAS00001003365",
+            "title": "Finding structural variation from the patient-derived xenografts of pediatric T-cell leukemia at the single-cell level",
+            "description": "In this study, we aimed to identify somatic structural variation of T-cell acute lymphoblastic leukemias (T-ALLs_ from patient-derived xenografts (PDX) at the single-cell level. For this purpose, we performed strand-specific single-cell sequencing of PDX-derived T-ALL relapse samples from two juvenile patients  (P1, P33). To validate structural variation detected via scTRIP, we profiled whole exome sequencing (WES) data from P33 (samples taken during initial disease, remission, relapse), and mate-pair sequencing data from P1 (relapse).",
+            "abstract": "In this study, we aimed to identify somatic structural variation of T-cell acute lymphoblastic leukemias (T-ALLs_ from patient-derived xenografts (PDX) at the single-cell level. For this purpose, we performed strand-specific single-cell sequencing of PDX-derived T-ALL relapse samples from two juvenile patients  (P1, P33). To validate structural variation detected via scTRIP, we profiled whole exome sequencing (WES) data from P33 (samples taken during initial disease, remission, relapse), and mate-pair sequencing data from P1 (relapse).",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001004499"
+            ],
+            "xref": [
+                "ena-STUDY-EMBL-05-12-2018-23:48:15:185-257"
+            ],
+            "creation_date": "2018-12-05T22:17.000Z"
+        },
+        {
+            "id": "EGAS00001003382",
+            "title": "Detection of mutational patterns in cell free DNA (cfDNA) of colorectal cancer by custom amplicon sequencing",
+            "description": "Monitoring the mutational patterns of solid tumors during cancer therapy is a major challenge in oncology. Analysis of mutations in cell free (cf) DNA offers a non-invasive approach to detect mutations that may be prognostic for disease survival or predictive for primary or secondary drug resistance. A main challenge for the application of cfDNA as a diagnostic tool is the diverse mutational landscape of cancer. Here, we developed a flexible end-to-end experimental and bioinformatics workflow to analyze mutations in cfDNA using custom amplicon sequencing. Our approach relies on open software tools to select primers suitable for multiplex PCR using minimal cfDNA as input. In addition, we developed a robust linear model to identify specific genetic alterations from sequencing data of cfDNA. We used our method to design a custom amplicon panel suitable for detection of hotspot mutations relevant for colorectal cancer and analyzed mutations in serial cfDNA samples from 34 patients with advanced colorectal cancer. Our data demonstrates that recurrent and patient-specific mutational patterns can be reliably detected for the majority of patients. Furthermore, we show that the allele frequency of mutations in cfDNA correlates well with disease progression. Finally, we demonstrate that monitoring of cfDNA can outperform the predictive power of currently used tumor markers and reveal mechanisms of resistance to anti-EGFR antibody treatment.",
+            "abstract": "Monitoring the mutational patterns of solid tumors during cancer therapy is a major challenge in oncology. Analysis of mutations in cell free (cf) DNA offers a non-invasive approach to detect mutations that may be prognostic for disease survival or predictive for primary or secondary drug resistance. A main challenge for the application of cfDNA as a diagnostic tool is the diverse mutational landscape of cancer. Here, we developed a flexible end-to-end experimental and bioinformatics workflow to analyze mutations in cfDNA using custom amplicon sequencing. Our approach relies on open software tools to select primers suitable for multiplex PCR using minimal cfDNA as input. In addition, we developed a robust linear model to identify specific genetic alterations from sequencing data of cfDNA. We used our method to design a custom amplicon panel suitable for detection of hotspot mutations relevant for colorectal cancer and analyzed mutations in serial cfDNA samples from 34 patients with advanced colorectal cancer. Our data demonstrates that recurrent and patient-specific mutational patterns can be reliably detected for the majority of patients. Furthermore, we show that the allele frequency of mutations in cfDNA correlates well with disease progression. Finally, we demonstrate that monitoring of cfDNA can outperform the predictive power of currently used tumor markers and reveal mechanisms of resistance to anti-EGFR antibody treatment.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001004574"
+            ],
+            "xref": [
+                "de8782ae-01c1-4624-b582-91ee76140c4e"
+            ],
+            "creation_date": "2018-12-12T14:20.000Z"
+        },
+        {
+            "id": "EGAS00001003405",
+            "title": "KIT-dependent and -independent genomic heterogeneity of resistance in gastrointestinal stromal tumors - TORC1/2 inhibition as salvage strategy",
+            "description": "The mutational status of GIST analyzed with a broad sequencing approach (WES, RNAseq)",
+            "abstract": "The mutational status of GIST analyzed with a broad sequencing approach (WES, RNAseq)",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001005113"
+            ],
+            "xref": [
+                "5363ff77-ce18-45a1-9e0e-b8a0bacd0fbe"
+            ],
+            "creation_date": "2018-12-19T13:27.000Z"
+        },
+        {
+            "id": "EGAS00001003481",
+            "title": "Mutational patterns and regulatory networks in epigenetic subgroups of meningioma (H033)",
+            "description": "DNA methylation patterns delineate clinically relevant subgroups of meningioma. We previously established the six meningioma methylation classes (MC) benign-1, 2, 3, intermediate-A, B and malignant.\n\nHere, we set out to identify subgroup-specific mutational patterns and pathway regulation. Whole-genome-sequencing was performed on 62 samples across all MCs and WHO grades from 62 patients with matched blood control, including 40 sporadic and 22 radiation-induced (Mrad) meningiomas. RNA sequencing was added for 18 cases and chromatin-immunoprecipitation for the enhancer mark H3K27ac followed by sequencing (ChIP-seq) for 16 samples.\n\nBesides the known mutations in meningioma, structural alterations were found to contribute to the spectrum of mechanisms inactivating NF2 in sporadic meningioma similar to previous reports for Mrad. Aberrations of DMD were found to be enriched in MCs with NF2 mutations and DMD was among the most differentially upregulated genes in NF2 mutant compared to NF2 wild-type cases. The mutational signature AC3 was detected in both sporadic meningioma and Mrad, but distributed across the genome in sporadic cases and enriched near genomic breakpoints in Mrad. In general, the malignant MC presented a significantly higher exposure to AC3 and higher genomic instability beyond the mutational load than the other MCs. Pathway analysis of the ChIP-seq clusters revealed that the FOXM1 is most differentially activated in high-grade cases, along with super enhancer recruitment near HOX genes and respective upregulation of expression.\n\nThis data further elucidate the biological mechanisms differentiating meningiomas of different WHO grade and epigenetic subgroups and suggest leveraging the genomic instability as novel therapeutic targets.",
+            "abstract": "DNA methylation patterns delineate clinically relevant subgroups of meningioma. We previously established the six meningioma methylation classes (MC) benign-1, 2, 3, intermediate-A, B and malignant.\n\nHere, we set out to identify subgroup-specific mutational patterns and pathway regulation. Whole-genome-sequencing was performed on 62 samples across all MCs and WHO grades from 62 patients with matched blood control, including 40 sporadic and 22 radiation-induced (Mrad) meningiomas. RNA sequencing was added for 18 cases and chromatin-immunoprecipitation for the enhancer mark H3K27ac followed by sequencing (ChIP-seq) for 16 samples.\n\nBesides the known mutations in meningioma, structural alterations were found to contribute to the spectrum of mechanisms inactivating NF2 in sporadic meningioma similar to previous reports for Mrad. Aberrations of DMD were found to be enriched in MCs with NF2 mutations and DMD was among the most differentially upregulated genes in NF2 mutant compared to NF2 wild-type cases. The mutational signature AC3 was detected in both sporadic meningioma and Mrad, but distributed across the genome in sporadic cases and enriched near genomic breakpoints in Mrad. In general, the malignant MC presented a significantly higher exposure to AC3 and higher genomic instability beyond the mutational load than the other MCs. Pathway analysis of the ChIP-seq clusters revealed that the FOXM1 is most differentially activated in high-grade cases, along with super enhancer recruitment near HOX genes and respective upregulation of expression.\n\nThis data further elucidate the biological mechanisms differentiating meningiomas of different WHO grade and epigenetic subgroups and suggest leveraging the genomic instability as novel therapeutic targets.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001005021",
+                "EGAD00001005061"
+            ],
+            "xref": [
+                "1895a4d8-3418-4848-b1cc-3f1ec190c384"
+            ],
+            "creation_date": "2019-02-15T14:52.000Z"
+        },
+        {
+            "id": "EGAS00001003776",
+            "title": "Targetable ERBB2 Mutations in Neurofibroma/Schwannoma Hybrid Nerve Sheath Tumors",
+            "description": "",
+            "abstract": "Neurofibroma/schwannoma hybrid nerve sheath tumors (N/S HNSTs) are neoplasms associated with larger nerves that occur sporadically and in the context of schwannomatosis or neurofibromatosis (NF). Clinical management of N/S HNST is challenging, especially for large tumors, and established systemic treatments are lacking. We identified activating mutations (p.Leu755Ser, p.Asp769Tyr, p.Val777Leu) in the catalytic domain of the ERBB2 receptor tyrosine kinase in schwannomatosis-associated (4 of 8 patients) N/S HNSTs but not in tumors arising in the context of NF (0 of 6 patients), and observed that ERBB2-mutant N/S HNSTs define a distinct subgroup of peripheral nerve sheath tumors based on genome-wide DNA methylation patterns. The small-molecule ERBB inhibitor lapatinib led to prolonged clinical benefit and a lasting radiographic and metabolic response in a patient with schwannomatosis-associated, ERBB2-mutant N/S HNST. These findings uncover a key biological feature of N/S HNST that may have important diagnostic and therapeutic implications. (H021)",
+            "type": "Cancer Genomics",
+            "has_dataset": [
+                "EGAD00001005249"
+            ],
+            "xref": [
+                "b640329f-a77b-4228-8fc7-0a7b5faf5cb8"
+            ],
+            "creation_date": "2019-07-26T09:04.000Z"
+        },
+        {
+            "id": "EGAS00001003923",
+            "title": "WES of 2 human osteosarcoma and corresponding cell lines",
+            "description": "Progress in the systemic control of osteosarcoma has been limited over the past decades thus indicating the urgent clinical need for the development of novel treatment strategies. Therefore, we have recently developed new preclinical models to study promising novel agents for the treatment of pediatric osteosarcoma. The checkpoint kinase (chk) inhibitor prexasertib (LY2606368) and its salt form (LSN2940930) have recently been shown to be active in adult and pediatric malignancies, including sarcoma. We have now tested the potency of prexasertib in clonogenic survival assays in two new lines of primary patient-derived osteosarcoma cells and in two established osteosarcoma cell lines as a single agent and in combination with cisplatin and the poly ADP-ribose polymerase (PARP) inhibitor talazoparib. Prexasertib alone results in strongly reduced clonogenic survival at low nanomolar concentrations and acts by affecting cell cycle progression, induction of apoptosis and induction of double-stranded DNA breakage at concentrations that are well below clinically tolerable and safe plasma concentrations. In combination with cisplatin and talazoparib, prexasertib acts in a synergistic fashion. Chk1 inhibition by prexasertib and its combination with the DNA damaging agent cisplatin and the PARP-inhibitor talazoparib thus emerges as a potential new treatment option for pediatric osteosarcoma which will now have to be tested in preclinical primary patient derived in vivo models and clinical studies.",
+            "abstract": "Progress in the systemic control of osteosarcoma has been limited over the past decades thus indicating the urgent clinical need for the development of novel treatment strategies. Therefore, we have recently developed new preclinical models to study promising novel agents for the treatment of pediatric osteosarcoma. The checkpoint kinase (chk) inhibitor prexasertib (LY2606368) and its salt form (LSN2940930) have recently been shown to be active in adult and pediatric malignancies, including sarcoma. We have now tested the potency of prexasertib in clonogenic survival assays in two new lines of primary patient-derived osteosarcoma cells and in two established osteosarcoma cell lines as a single agent and in combination with cisplatin and the poly ADP-ribose polymerase (PARP) inhibitor talazoparib. Prexasertib alone results in strongly reduced clonogenic survival at low nanomolar concentrations and acts by affecting cell cycle progression, induction of apoptosis and induction of double-stranded DNA breakage at concentrations that are well below clinically tolerable and safe plasma concentrations. In combination with cisplatin and talazoparib, prexasertib acts in a synergistic fashion. Chk1 inhibition by prexasertib and its combination with the DNA damaging agent cisplatin and the PARP-inhibitor talazoparib thus emerges as a potential new treatment option for pediatric osteosarcoma which will now have to be tested in preclinical primary patient derived in vivo models and clinical studies.",
+            "type": "Other",
+            "has_dataset": [
+                "EGAD00001005370"
+            ],
+            "xref": [
+                "60445aa0-34f1-4f4b-90ae-d74a03f9ae31"
+            ],
+            "creation_date": "2019-10-01T09:41.000Z"
+        }
+    ]
+}

--- a/metadata_service/models.py
+++ b/metadata_service/models.py
@@ -22,6 +22,9 @@ class Publication(BaseModel):
     __collection__: str = "publication"
     id: str
     title: Optional[str] = None
+    xref: Optional[List[str]] = None
+    creation_date: Optional[str] = None
+    update_date: Optional[str] = None
 
 
 class Experiment(BaseModel):
@@ -30,6 +33,9 @@ class Experiment(BaseModel):
     id: str
     name: Optional[str] = None
     instrument_model: Optional[str] = None
+    xref: Optional[List[str]] = None
+    creation_date: Optional[str] = None
+    update_date: Optional[str] = None
 
 
 class Study(BaseModel):
@@ -40,10 +46,13 @@ class Study(BaseModel):
     __collection__: str = "study"
     id: str
     title: Optional[str] = None
-    type: Optional[str] = None
+    type: Optional[Union[str, List]] = None
     abstract: Optional[str] = None
     publications: Optional[List[Union[str, Publication]]] = None
     has_experiment: Optional[Union[str, Experiment]] = None
+    xref: Optional[List[str]] = None
+    creation_date: Optional[str] = None
+    update_date: Optional[str] = None
 
 
 class File(BaseModel):
@@ -52,10 +61,13 @@ class File(BaseModel):
     id: str
     name: Optional[str]
     format: Optional[str]
-    type: Optional[str]
+    type: Optional[Union[str, List]]
     size: Optional[str]
     checksum: Optional[str]
     category: Optional[str]
+    xref: Optional[List[str]] = None
+    creation_date: Optional[str] = None
+    update_date: Optional[str] = None
 
 
 class DataAccessCommittee(BaseModel):
@@ -66,6 +78,9 @@ class DataAccessCommittee(BaseModel):
     description: Optional[str] = None
     main_contact: Optional[str] = None
     has_members: Optional[List[str]] = None
+    xref: Optional[List[str]] = None
+    creation_date: Optional[str] = None
+    update_date: Optional[str] = None
 
 
 class DataAccessPolicy(BaseModel):
@@ -76,7 +91,9 @@ class DataAccessPolicy(BaseModel):
     policy_text: Optional[str] = None
     policy_url: Optional[str] = None
     has_data_access_committee: Optional[Union[str, DataAccessCommittee]] = None
-
+    xref: Optional[List[str]] = None
+    creation_date: Optional[str] = None
+    update_date: Optional[str] = None
 
 class Dataset(BaseModel):
     __references__: Set = {
@@ -88,7 +105,10 @@ class Dataset(BaseModel):
     id: str
     title: Optional[str] = None
     description: Optional[str] = None
-    type: Optional[str] = None
+    type: Optional[Union[str, List]] = None
     files: Optional[List[Union[str, File]]] = None
     has_study: Optional[Union[str, Study]] = None
     has_data_access_policy: Optional[Union[str, DataAccessPolicy]] = None
+    xref: Optional[List[str]] = None
+    creation_date: Optional[str] = None
+    update_date: Optional[str] = None

--- a/scripts/populate_metadata_store.py
+++ b/scripts/populate_metadata_store.py
@@ -46,7 +46,6 @@ def populate_record(
     if os.path.exists(file):
         with open(file) as records_file:
             records = json.load(records_file)
-        print(records)
         route = f"{base_url}/{record_type}"
         for record in records[record_type]:
             response = requests.post(route, json=record)

--- a/scripts/translate_ega_to_ghga.py
+++ b/scripts/translate_ega_to_ghga.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Translate EGA metadata JSON to GHGA Schema compatible JSON"""
+
+import os
+import uuid
+import json
+from pathlib import Path
+from typing import List, Dict, Union
+import typer
+
+
+ghga_objects: Dict = {
+    "members": {},
+    "data_access_committees": {},
+    "data_access_policies": {},
+    "studies": {},
+    "datasets": {},
+    "files": {},
+    "publications": {}
+}
+
+
+def parse_ega_dacs(dacs: List[Dict]):
+    """Translate EGA DAC to GHGA DataAccessCommittee objects"""
+    for dac in dacs:
+        ghga_dac = {
+            "id": dac["egaStableId"],
+            "title": dac["title"],
+            "main_contact": None,
+            "xref": [],
+        }
+        if dac["alias"]:
+            ghga_dac["xref"].append(dac["alias"])
+        if "creationTime" in dac:
+            ghga_dac["creation_date"] = dac["creationTime"]
+        ghga_objects["data_access_committees"][ghga_dac["id"]] = ghga_dac
+
+        for contact in dac["contacts"]:
+            # Translate contacts of an EGA DAC to GHGA Member objects
+            ghga_member = {
+                "id": str(uuid.uuid4()),
+                "name": contact["contactName"],
+                "email": contact["email"],
+                "telephone": contact["phoneNumber"],
+                "organization": contact["organisation"],
+            }
+            if ghga_member["id"] in ghga_objects["members"]:
+                ghga_objects["members"][ghga_member["id"]].update(ghga_member)
+            else:
+                ghga_objects["members"][ghga_member["id"]] = ghga_member
+            if contact["mainContact"]:
+                # Contact is marked as the main contact for this DAC
+                ghga_dac["main_contact"] = ghga_dac["id"]
+
+
+def parse_ega_datasets(datasets: List[Dict]):
+    """Translate EGA Dataset to GHGA Dataset objects"""
+    for dataset in datasets:
+        ghga_dataset = {
+            "id": dataset["egaStableId"],
+            "title": dataset["title"],
+            "description": dataset["description"],
+            "type": dataset["datasetTypes"],
+            "has_data_access_policy": dataset["policyStableId"],
+            "xref": [],
+        }
+        if dataset["alias"]:
+            ghga_dataset["xref"].append(dataset["alias"])
+        if "creationTime" in dataset:
+            ghga_dataset["creation_date"] = dataset["creationTime"]
+        if dataset["dacs"]:
+            dacs = dataset["dacs"]
+            if len(dacs) > 1:
+                raise ValueError(
+                    f"More than one EGA DAC associated with the same dataset: {dataset}"
+                )
+            dap = {
+                "id": ghga_dataset["has_data_access_policy"],
+                "has_data_access_committee": dacs[0],
+            }
+            ghga_objects["data_access_policies"][dap["id"]] = dap
+        ghga_objects["datasets"][ghga_dataset["id"]] = ghga_dataset
+
+        ghga_dap = {"id": dataset["policyStableId"]}
+        if ghga_dap["id"] in ghga_objects["data_access_policies"]:
+            ghga_objects["data_access_policies"][ghga_dap["id"]].update(ghga_dap)
+        else:
+            ghga_objects["data_access_policies"][ghga_dap["id"]] = ghga_dap
+
+
+def parse_ega_studies(studies: List[Dict]):
+    """Translate EGA Study to GHGA Study objects"""
+    for study in studies:
+        ghga_study = {
+            "id": study["egaStableId"],
+            "title": study["title"],
+            "description": study["description"],
+            "abstract": study["studyAbstract"],
+            "type": study["studyType"],
+            "has_dataset": study["datasets"],
+            "xref": [],
+        }
+        if study["alias"]:
+            ghga_study["xref"].append(study["alias"])
+        if "creationTime" in study:
+            ghga_study["creation_date"] = study["creationTime"]
+        ghga_objects["studies"][ghga_study["id"]] = ghga_study
+
+        if study["pubMedIds"]:
+            # Translate pubMedIds to GHGA Publication objects
+            for publication in study["pubMedIds"]:
+                ghga_publication = {"id": publication}
+            if ghga_publication["id"] in ghga_objects["publications"]:
+                ghga_objects["publications"][ghga_publication["id"]].update(
+                    ghga_publication
+                )
+            else:
+                ghga_objects["publications"][ghga_publication["id"]] = ghga_publication
+
+        for dataset_id in study["datasets"]:
+            ghga_dataset = {"id": dataset_id}
+            if ghga_dataset["id"] in ghga_objects["datasets"]:
+                dataset = ghga_objects["datasets"][dataset_id]
+                dataset["has_study"] = ghga_study["id"]
+            else:
+                raise KeyError(f"Error: Dataset {ghga_dataset['id']} does not exist!")
+
+
+def main(
+    ega_dac_json: List[Path] = None,
+    ega_dataset_json: List[Path] = None,
+    ega_studies_json: List[Path] = None,
+    output: str = os.getcwd(),
+    output_prefix: str = None,
+):
+    """Translate EGA metadata JSON to GHGA compatible JSON"""
+    if ega_dac_json:
+        for file in ega_dac_json:
+            parse_ega_dacs(json.load(open(file)))
+    if ega_dataset_json:
+        for file in ega_dataset_json:
+            parse_ega_datasets(json.load(open(file)))
+    if ega_studies_json:
+        for file in ega_studies_json:
+            parse_ega_studies(json.load(open(file)))
+
+    for coll_name, items in ghga_objects.items():
+        items_list = list(items.values())
+        if len(items) > 0:
+            output_object = {coll_name: items_list}
+            if output_prefix:
+                filename = f"{output}{os.path.sep}{output_prefix}_{coll_name}.json"
+            else:
+                filename = f"{output}{os.path.sep}{coll_name}.json"
+            json.dump(output_object, open(filename, "w"), indent=4)
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
This PR adds the following:
- Add a script to transform EGA metadata to GHGA-compatible form
- Update `populate_metadata_store.py` script to load JSON from a given folder
- Update `models.py` to accommodate new attributes
- Add original EGA metadata JSON and its transformed GHGA-compatible variants
