### PR TITLE
Initialize the the counter for a collection when it does not exist in the metadata store

### DIFF
--- a/metadata_service/database.py
+++ b/metadata_service/database.py
@@ -57,8 +57,27 @@ class DBConnect:
         """
         This method generates the sequence id for the MongoDB document
         """
+        await self._check_collection_counter(collection_name)
         collection = await self.get_collection(COUNTER)
         document = await collection.find_one({"_id": collection_name})  # type: ignore
         collection.update_one({"_id": collection_name}, {"$inc": {"value": 1}})  # type: ignore
         await self.close_db()
         return prefix + f"{(document['value'] + 1):07}"
+
+    async def _check_collection_counter(self, collection_name: str):
+        """
+        Check whether counter for a given collection exists.
+        """
+        db_connect = DBConnect()
+        collection = await db_connect.get_collection(name=COUNTER)
+        docs = await collection.find({"_id": collection_name}).to_list(None)  # type: ignore
+        if not docs:
+            await self._initialize_collection_counter(collection_name)
+
+    async def _initialize_collection_counter(self, collection_name: str):
+        """
+        Initialize a counter for a given collection.
+        """
+        db_connect = DBConnect()
+        collection = await db_connect.get_collection(name=COUNTER)
+        collection.insert_one({"_id": collection_name, "value": 0})  # type: ignore


### PR DESCRIPTION
This PR add a check to DBConnect such that when trying to fetch a new ID for a record, the check is performed to ensure that the counter is available as a starting point. If not, a new one is created.