### PR TITLE
Explicitly define the endpoint for docs and OpenAPI JSON

### DIFF
--- a/metadata_service/api.py
+++ b/metadata_service/api.py
@@ -36,6 +36,8 @@ from metadata_service import __version__
 app = FastAPI(
     title="Metadata Service API",
     version=__version__,
+    openapi_url="/metadata/docs/openapi.json",
+    docs_url="/metadata/docs"
 )
 configure_app(app, config=get_config())
 


### PR DESCRIPTION
This PR changes the following endpoints:
- `localhost:8000/docs` -> `localhost:8000/metadata/docs`
- `localhost:8000/openapi.json` -> `localhost:8000/metadata/docs/openapi.json`