### PR TITLE
Fix id for publications in examples

### DIFF
--- a/examples/publications.json
+++ b/examples/publications.json
@@ -13,7 +13,7 @@
             "title": "A publication associated with STU:0000002"
         },
         {
-            "id": "DOI:00001234",
+            "id": "PMID:0000004",
             "title": "A publication associated with STU:0000002"
         }
     ]

--- a/examples/studies.json
+++ b/examples/studies.json
@@ -18,7 +18,7 @@
             "abstract": "Whole exome sequencing of an individual with an uncharacterized disease",
             "publications": [
                 "PMID:0000003",
-                "DOI:00001234"
+                "PMID:0000004"
             ],
             "has_experiment": "EXP:0000002"
         }


### PR DESCRIPTION
This fixes the IDs used in the publication example JSON.
